### PR TITLE
Fix typo in memory.md

### DIFF
--- a/_chapters_en/memory.md
+++ b/_chapters_en/memory.md
@@ -189,7 +189,7 @@ taught and practiced if they are to be effective.
 > 
 > When asked to draw their first concept map, many people will stare at
 > the blank page in front of them, not knowing where to start. When this
-> happens, right down two words associated with the topic you're trying
+> happens, write down two words associated with the topic you're trying
 > to map, then draw a line between them and add a label explaining how
 > those two ideas are related. You can then ask what other things are
 > related in the same way, what parts those things have, or what happens


### PR DESCRIPTION
Typo: "right down two words" → "write down two words"

---

Thank you writing this book! I'm reading it voraciously, and plan to apply as much as I can in practice.
While reading the Expertise and Memory chapter I noticed this typo.
