### PR TITLE
Repair broken link to all/aio page

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -4,7 +4,7 @@
   {% assign chapters = site.chapters_um %}
 {% endif %}
 {% assign licensepath = '/' | append: include.language | append: '/license/' %}
-{% assign allpath = '/' | append: include.language | append: '/all/' %}
+{% assign allpath = '/' | append: include.language | append: '/all' %}
 
 <nav>
   {% if page.root %}<strong><a href="./">{% else %}<a href="../">{% endif %}


### PR DESCRIPTION
[`/all/` works locally with Jekyll, but GitHub servers a 404](http://teachtogether.tech/en/all/). This problem can [also](http://teachtogether.tech/en/all) be solved by expanding the append rule to [`/all.html`](http://teachtogether.tech/en/all.html).