### PR TITLE
Redo layout so that it works well on mobile

### DIFF
--- a/assets/book.css
+++ b/assets/book.css
@@ -20,19 +20,18 @@ h1.unnumbered {
     border-top-style: none;
 }
 
-div.row-scrollable {
-    height: 100vh;
+@media (min-width: 768px) {
+    .col-toc {
+        position: sticky;
+        position: -webkit-sticky;
+        top: 0;
+        height: 100vh;
+        overflow-y: scroll;
+    }
 }
 
-div.col-toc {
-    height: 100%;
-    overflow-y: scroll;
+.col-toc {
     font-size: 90%;
-}
-
-div.col-body {
-    height: 100%;
-    overflow-y: scroll;
 }
 
 div.dedication {

--- a/docs/assets/book.css
+++ b/docs/assets/book.css
@@ -20,19 +20,18 @@ h1.unnumbered {
     border-top-style: none;
 }
 
-div.row-scrollable {
-    height: 100vh;
+@media (min-width: 768px) {
+    .col-toc {
+        position: sticky;
+        position: -webkit-sticky;
+        top: 0;
+        height: 100vh;
+        overflow-y: scroll;
+    }
 }
 
-div.col-toc {
-    height: 100%;
-    overflow-y: scroll;
+.col-toc {
     font-size: 90%;
-}
-
-div.col-body {
-    height: 100%;
-    overflow-y: scroll;
 }
 
 div.dedication {

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,8 +21,8 @@
 </head>
 <body>
 <div class="container-fluid">
-  <div class="row row-scrollable">
-    <div class="col-md-2 col-toc">
+  <div class="row">
+    <nav class="col-md-2 col-toc">
       <a href="#title-block-header"><img src="assets/logo.svg" alt="Teaching Tech Together" width="100%" /></a>
 <nav id="TOC" role="doc-toc">
 <ul>
@@ -180,33 +180,34 @@
         <a href="mailto:gvwilson@third-bit.com?subject=Teaching Tech Together"><img src="assets/email.svg" alt="Email" width="20%" /></a>
         <a href="https://github.com/gvwilson/teachtogether.tech/"><img src="assets/github.svg" alt="GitHub" width="20%" /></a>
       </p>
-    </div>
-    <div class="col-md-8 col-body">
-      <header>
-        <h1 class="title">Teaching Tech Together</h1>
-                <p class="subtitle">How to create and deliver lessons that work<br />
+    </nav>
+    <div class="col-md-10 col-body">
+      <div class="container">
+        <header>
+          <h1 class="title">Teaching Tech Together</h1>
+                    <p class="subtitle">How to create and deliver lessons that work<br />
 and build a teaching community around them</p>
-                        <p class="author"><a href="http://third-bit.com">Greg Wilson</a></p>
-                        <p class="date">Version 4.0 beta / June 2019</p>
-              </header>
-      <div class="dedication">
-        <p><strong>Dedication</strong></p>
-        <p>
-          For my mother, Doris Wilson,<br/>
-          who taught hundreds of children to read and to believe in themselves.<br/>
-        </p>
-        <p>
-          And for my brother Jeff, who did not live to see it finished.<br/>
-          "Remember, you still have a lot of good times in front of you."<br/>
-        </p>
-        <p>
-          All royalties from the sale of this book are being donated to<br/>
-          the Carpentries,<br/>
-          a volunteer organization that teaches<br/>
-          foundational coding and data science skills<br/>
-          to researchers worldwide.
-        </p>
-      </div>
+                              <p class="author"><a href="http://third-bit.com">Greg Wilson</a></p>
+                              <p class="date">Version 4.0 beta / June 2019</p>
+                  </header>
+        <div class="dedication">
+          <p><strong>Dedication</strong></p>
+          <p>
+            For my mother, Doris Wilson,<br/>
+            who taught hundreds of children to read and to believe in themselves.<br/>
+          </p>
+          <p>
+            And for my brother Jeff, who did not live to see it finished.<br/>
+            "Remember, you still have a lot of good times in front of you."<br/>
+          </p>
+          <p>
+            All royalties from the sale of this book are being donated to<br/>
+            the Carpentries,<br/>
+            a volunteer organization that teaches<br/>
+            foundational coding and data science skills<br/>
+            to researchers worldwide.
+          </p>
+        </div>
 
 
 
@@ -436,7 +437,7 @@ d) 43</p>
 <h3 id="thinking-things-through-whole-class15" class="unnumbered unnumbered">Thinking Things Through (whole class/15)</h3>
 <p>A good formative assessment requires people to think through a problem. For example, imagine that you have placed a block of ice in a bathtub and then filled the tub to the rim with water. When the ice melts, does the water level go up (so that the tub overflows), go down, or stay the same (Figure <a href="#f:models-bathtub" data-reference-type="ref" data-reference="f:models-bathtub">[f:models-bathtub]</a>)?</p>
 <figure>
-<img src="figures/bathtub.svg" id="f:models-bathtub" /><figcaption>Ice in a bathtub<span label="f:models-bathtub"></span></figcaption>
+<img src="figures/bathtub.svg" /><figcaption>Ice in a bathtub<span label="f:models-bathtub"></span></figcaption>
 </figure>
 <p>The correct answer is that the level stays the same: the ice displaces its own weight in water, so it exactly fills the “hole” it has made when it melts. Figuring out why helps people build a model of the relationship between weight, volume, and density [<a class="cite" href="#ref-Epst2002">Epst2002</a>].</p>
 <p>Describe another formative assessment you have seen or used that required people to think something through and thereby identify flaws in their reasoning. When you are done, explain your example to a partner and give them feedback on theirs.</p>
@@ -482,10 +483,10 @@ d) 43</p>
 
 <h2 id="review" class="unnumbered unnumbered">Review</h2>
 <figure>
-<img src="figures/conceptmap-mental-models.svg" id="f:models-concept-map" /><figcaption>Concepts: Mental models<span label="f:models-concept-map"></span></figcaption>
+<img src="figures/conceptmap-mental-models.svg" /><figcaption>Concepts: Mental models<span label="f:models-concept-map"></span></figcaption>
 </figure>
 <figure>
-<img src="figures/conceptmap-assessment.svg" id="f:models-formative-assessment" /><figcaption>Concepts: Assessment<span label="f:models-formative-assessment"></span></figcaption>
+<img src="figures/conceptmap-assessment.svg" /><figcaption>Concepts: Assessment<span label="f:models-formative-assessment"></span></figcaption>
 </figure>
 <h1 id="s:memory">Expertise and Memory</h1>
 <blockquote>
@@ -510,7 +511,7 @@ d) 43</p>
 <h2 id="s:memory-concept-maps">Concept Maps</h2>
 <p>Our tool of choice for representing someone’s mental model is a <a href="#g:concept-map"><strong>concept map</strong></a>, in which facts are bubbles and connections are labeled connections. As examples, Figure <a href="#f:memory-seasons" data-reference-type="ref" data-reference="f:memory-seasons">[f:memory-seasons]</a> shows why the Earth has seasons (from <a href="https://cmap.ihmc.us/">IHMC</a>), and Appendix <a href="#s:conceptmaps" data-reference-type="ref" data-reference="s:conceptmaps">22</a> presents concept maps for libraries from three points of view.</p>
 <figure>
-<img src="figures/seasons.svg" id="f:memory-seasons" /><figcaption>Concept map for seasons<span label="f:memory-seasons"></span></figcaption>
+<img src="figures/seasons.svg" /><figcaption>Concept map for seasons<span label="f:memory-seasons"></span></figcaption>
 </figure>
 <p>To show how concept maps can be using in teaching programming, consider this <code>for</code> loop in Python:</p>
 <pre class="text"><code>for letter in &quot;abc&quot;:
@@ -521,7 +522,7 @@ b
 c</code></pre>
 <p>The three key “things” in this loop are shown in the top of Figure <a href="#f:memory-loop" data-reference-type="ref" data-reference="f:memory-loop">[f:memory-loop]</a>, but they are only half the story. The expanded version in the bottom shows the relationships between those things, which are as important for understanding as the concepts themselves.</p>
 <figure>
-<img src="figures/for-loop.svg" id="f:memory-loop" /><figcaption>Concept map for a <code>for</code> loop<span label="f:memory-loop"></span></figcaption>
+<img src="figures/for-loop.svg" /><figcaption>Concept map for a <code>for</code> loop<span label="f:memory-loop"></span></figcaption>
 </figure>
 
 <p>Concept maps can be used in many ways:</p>
@@ -559,7 +560,7 @@ c</code></pre>
 <p>7±2 is the single most important number in teaching. A teacher cannot place information directly in a learner’s long-term memory. Instead, whatever they present is first stored in the learner’s short-term memory, and is only transferred to long-term memory after it has been held there and rehearsed (Section <a href="#s:individual-strategies" data-reference-type="ref" data-reference="s:individual-strategies">5.1</a>). If the teacher presents too much information too quickly, the new information displaces the old before the latter is transferred.</p>
 <p>This is one of the ways to use a concept map when designing a lesson: it helps make sure learners’ short-term memories won’t be overloaded. Once the map is drawn, the teacher chooses a subsection that will fit in short-term memory and lead to a formative assessment (Figure <a href="#f:memory-photosynthesis" data-reference-type="ref" data-reference="f:memory-photosynthesis">[f:memory-photosynthesis]</a>), then adds another subsection for the next lesson episode and so on.</p>
 <figure>
-<img src="figures/photosynthesis.svg" id="f:memory-photosynthesis" /><figcaption>Using concept maps in lesson design<span label="f:memory-photosynthesis"></span></figcaption>
+<img src="figures/photosynthesis.svg" /><figcaption>Using concept maps in lesson design<span label="f:memory-photosynthesis"></span></figcaption>
 </figure>
 <blockquote>
 <h4 id="building-concept-maps-together" class="unnumbered unnumbered">Building Concept Maps Together</h4>
@@ -612,13 +613,13 @@ c</code></pre>
 <h3 id="the-power-of-chunking-individual5" class="unnumbered unnumbered">The Power of Chunking (individual/5)</h3>
 <p>Look at Figure <a href="#f:memory-unchunked" data-reference-type="ref" data-reference="f:memory-unchunked">[f:memory-unchunked]</a> for 10 seconds, then look away and try to write out your phone number with these symbols<a href="#fn49" class="footnote-ref" id="fnref49"><sup>49</sup></a>. (Use a space for ’0’.) When you are finished, look at the alternative representation in Appendix <a href="#s:chunking" data-reference-type="ref" data-reference="s:chunking">23</a>. How much easier are the symbols to remember when the pattern is made explicit?</p>
 <figure>
-<img src="figures/chunking-unchunked.svg" id="f:memory-unchunked" /><figcaption>Unchunked representation<span label="f:memory-unchunked"></span></figcaption>
+<img src="figures/chunking-unchunked.svg" /><figcaption>Unchunked representation<span label="f:memory-unchunked"></span></figcaption>
 </figure>
 <h1 id="s:architecture">Cognitive Architecture</h1>
 <p>We have been talking about mental models as if they were real things, but what actually goes on in a learner’s brain when they’re learning? The short answer is that we don’t know; the longer answer is that we know a lot more than we used to. This chapter will dig a little deeper into what brains do while they’re learning and how we can leverage that to design and deliver lessons more effectively.</p>
 <h2 id="s:architecture-brain">What’s Going On In There?</h2>
 <figure>
-<img src="figures/cognitive-architecture.svg" id="f:arch-model" /><figcaption>Cognitive architecture<span label="f:arch-model"></span></figcaption>
+<img src="figures/cognitive-architecture.svg" /><figcaption>Cognitive architecture<span label="f:arch-model"></span></figcaption>
 </figure>
 <p>Figure <a href="#f:arch-model" data-reference-type="ref" data-reference="f:arch-model">[f:arch-model]</a> is a simplified model of human cognitive architecture. The core of this model is the separation between short-term and long-term memory discussed in Section <a href="#s:memory-seven-plus-or-minus" data-reference-type="ref" data-reference="s:memory-seven-plus-or-minus">3.2</a>. Long-term memory is like your basement: it stores things more or less permanently, but you can’t access its contents directly. Instead, you rely on your short-term memory, which is the cluttered kitchen table of your mind.</p>
 <p>When you need something, your brain retrieves it from long-term memory and puts it in short-term memory. Conversely, new information that arrives in short-term memory has to be encoded to be stored in long-term memory. If that information isn’t encoded and stored, it’s not remembered and learning hasn’t taken place.</p>
@@ -657,7 +658,7 @@ c</code></pre>
 <h3 id="parsons-problems" class="unnumbered unnumbered">Parsons Problems</h3>
 <p>One kind of exercise that can be explained in terms of cognitive load is often used when teaching languages. Suppose you ask someone to translate the sentence, “How is her knee today?” into Frisian. To solve the problem, they need to recall both vocabulary and grammar, which is a double cognitive load. If you ask them to put “hoe,” “har,” “is,” “hjoed,” and “knie” in the right order, on the other hand, you are allowing them to focus solely on learning grammar. If you write these words in five different fonts or colors, though, you have increased the extraneous cognitive load, because they will involuntarily (and possibly unconsciously) expend some effort trying to figure out if the differences are meaningful (Figure <a href="#f:architecture-frisian" data-reference-type="ref" data-reference="f:architecture-frisian">[f:architecture-frisian]</a>).</p>
 <figure>
-<img src="figures/frisian.png" alt="Constructing a sentence" id="f:architecture-frisian" /><figcaption>Constructing a sentence<span label="f:architecture-frisian"></span></figcaption>
+<img src="figures/frisian.png" alt="Constructing a sentence" /><figcaption>Constructing a sentence<span label="f:architecture-frisian"></span></figcaption>
 </figure>
 <p>The coding equivalent of this is called a <a href="#g:parsons-problem"><strong>Parsons Problem</strong></a><a href="#fn56" class="footnote-ref" id="fnref56"><sup>56</sup></a> [<a class="cite" href="#ref-Pars2006">Pars2006</a>]. When teaching people to program, you can give them the lines of code they need to solve a problem and ask them to put them in the right order. This allows them to concentrate on control flow and data dependencies without being distracted by variable naming or trying to remember what functions to call. Multiple studies have shown that Parsons Problems take less time for learners to do but produce equivalent educational outcomes [<a class="cite" href="#ref-Eric2017">Eric2017</a>].</p>
 <h3 id="faded-examples" class="unnumbered unnumbered">Faded Examples</h3>
@@ -875,7 +876,7 @@ define make_acronym(list_of_words):
 <p>Choose a video of a lesson or talk online that uses slides or other static presentations and rate its graphics as “poor,” “average,” or “good” according to these six criteria.</p>
 <h2 id="review-1" class="unnumbered unnumbered">Review</h2>
 <figure>
-<img src="figures/conceptmap-cognitive-load.svg" id="f:architecture-cognitive-load" /><figcaption>Concepts: Cognitive load<span label="f:architecture-cognitive-load"></span></figcaption>
+<img src="figures/conceptmap-cognitive-load.svg" /><figcaption>Concepts: Cognitive load<span label="f:architecture-cognitive-load"></span></figcaption>
 </figure>
 <h1 id="s:individual">Individual Learning</h1>
 <p>Previous chapters have explored what teachers can do to help learners. This chapter looks at what learners can do for themselves by changing their study strategies and getting enough rest.</p>
@@ -1018,7 +1019,7 @@ define make_acronym(list_of_words):
 </ol>
 <h2 id="review-2" class="unnumbered unnumbered">Review</h2>
 <figure>
-<img src="figures/conceptmap-active-learning.svg" id="f:individual-concept-map" /><figcaption>Concepts: Active learning<span label="f:individual-concept-map"></span></figcaption>
+<img src="figures/conceptmap-active-learning.svg" /><figcaption>Concepts: Active learning<span label="f:individual-concept-map"></span></figcaption>
 </figure>
 <h1 id="s:process">A Lesson Design Process</h1>
 <p>Most people design lessons like this:</p>
@@ -1204,7 +1205,7 @@ This starts with an active verb, defines the level of learning, and provides con
 <p>In small groups, discuss whether these three features would be enough to convince you to use a lesson sharing site, and if not, what would.</p>
 <h2 id="review-3" class="unnumbered unnumbered">Review</h2>
 <figure>
-<img src="figures/conceptmap-personas.svg" id="f:process-personas" /><figcaption>Concepts: Learner personas<span label="f:process-personas"></span></figcaption>
+<img src="figures/conceptmap-personas.svg" /><figcaption>Concepts: Learner personas<span label="f:process-personas"></span></figcaption>
 </figure>
 <h1 id="s:pck">Pedagogical Content Knowledge</h1>
 <p>Every teacher needs three things:</p>
@@ -1285,7 +1286,7 @@ This starts with an active verb, defines the level of learning, and provides con
 <p>High-level topic labels like these can hide a multitude of sins. A more tangible result comes from,[<a class="cite" href="#ref-Rich2017">Rich2017</a>] which reviewed a hundred articles to find learning trajectories for computing classes in elementary and middle schools. Their results for sequencing, repetition, and conditionals are essentially collective concept maps that combine and rationalize the implicit and explicit thinking of many different educators (Figure <a href="#f:pck-trajectory" data-reference-type="ref" data-reference="f:pck-trajectory">[f:pck-trajectory]</a>).</p>
 
 <figure>
-<img src="figures/conditionals.svg" id="f:pck-trajectory" /><figcaption>Learning trajectory for conditions (from [<a class="cite" href="#ref-Rich2017">Rich2017</a>])<span label="f:pck-trajectory"></span></figcaption>
+<img src="figures/conditionals.svg" /><figcaption>Learning trajectory for conditions (from [<a class="cite" href="#ref-Rich2017">Rich2017</a>])<span label="f:pck-trajectory"></span></figcaption>
 </figure>
 <h2 id="s:pck-learning">How Much Are They Learning?</h2>
 <p>There can be a world of difference between what teachers teach and how much learners learn. To explore the latter, we must use other measures or do direct studies. Taking the former approach, roughly two-thirds of post-secondary students pass their first computing course, with some variations depending on class size and so on, but with no significant differences over time or based on language [<a class="cite" href="#ref-Benn2007a">Benn2007a</a>,<a class="cite" href="#ref-Wats2014">Wats2014</a>].</p>
@@ -1354,7 +1355,7 @@ print(total)</code></pre>
 <p>The short answer is “yes”: novices learn to program faster and learn more using blocks-based tools like Scratch (Figure <a href="#f:pck-scratch" data-reference-type="ref" data-reference="f:pck-scratch">[f:pck-scratch]</a>) [<a class="cite" href="#ref-Wein2017">Wein2017</a>]. One reason is that blocks-based systems reduce cognitive load by eliminating the possibility of syntax errors. Another is that block interfaces encourage exploration in a way that text does not: like all good tools, Scratch can be learned accidentally [<a class="cite" href="#ref-Malo2010">Malo2010</a>].</p>
 <p>But what happens <em>after</em> blocks?[<a class="cite" href="#ref-Chen2018">Chen2018</a>] found that learners whose first programming language was graphical had higher grades in introductory programming courses than learners whose first language was textual when the languages were introduced in or before early adolescent years. Our sixth recommendation is therefore to <em>start children and teens with blocks-based interfaces</em> before moving to text-based systems. The age qualification is there because Scratch deliberately looks like it’s meant for younger users, and it can still be hard to convince adults to take it seriously.</p>
 <figure>
-<img src="figures/scratch-program.png" alt="Scratch" id="f:pck-scratch" /><figcaption>Scratch<span label="f:pck-scratch"></span></figcaption>
+<img src="figures/scratch-program.png" alt="Scratch" /><figcaption>Scratch<span label="f:pck-scratch"></span></figcaption>
 </figure>
 <p>Scratch has probably been studied more than any other programming tool. One example is [<a class="cite" href="#ref-Aiva2016">Aiva2016</a>], which analyzed over 250,000 Scratch projects and found (among other things) that about 28% of projects have some blocks that are never called or triggered. As in the earlier aside about incomplete versus incorrect Java programs, the authors hypothesize that users may be using these blocks as a scratchpad to keep track of bits of code they don’t (yet) want to throw away. Another example is [<a class="cite" href="#ref-Grov2017">Grov2017</a>,<a class="cite" href="#ref-Mlad2017">Mlad2017</a>], which studied novices learning about loops in Scratch, Logo, and Python. They found that misconceptions about loops are minimized when using a block-based language rather than a text-based language. What’s more, as tasks become more complex (such as using nested loops) the differences become larger.</p>
 <blockquote>
@@ -1425,7 +1426,7 @@ If &quot;string&quot; refers to a datatype, capitalize the &#39;s&#39;!</code></
 </dd>
 </dl>
 <figure>
-<img src="figures/interventions-scaled.png" alt="Effectiveness of interventions" id="f:pck-interventions" /><figcaption>Effectiveness of interventions<span label="f:pck-interventions"></span></figcaption>
+<img src="figures/interventions-scaled.png" alt="Effectiveness of interventions" /><figcaption>Effectiveness of interventions<span label="f:pck-interventions"></span></figcaption>
 </figure>
 <p>This list highlights the importance of cooperative learning.[<a class="cite" href="#ref-Beck2013">Beck2013</a>] looked at this specifically over three academic years in courses taught by two different teachers and found significant benefits overall and for many subgroups. The cooperators had higher grades and left fewer questions blank on the final exam, which indicates greater self-efficacy and willingness to try to debug things.</p>
 <blockquote>
@@ -1614,7 +1615,7 @@ If &quot;string&quot; refers to a datatype, capitalize the &#39;s&#39;!</code></
 <h2 id="s:performance-feedback">Giving and Getting Feedback on Teaching</h2>
 <p>Observing someone helps you, and giving them feedback helps them, but it can be hard to receive feedback, especially when it’s negative (Figure <a href="#f:performance-feedback-feelings" data-reference-type="ref" data-reference="f:performance-feedback-feelings">[f:performance-feedback-feelings]</a>).</p>
 <figure>
-<img src="figures/deathbulge-jerk.jpg" alt="Feedback feelings (copyright © Deathbulge 2013)" id="f:performance-feedback-feelings" /><figcaption>Feedback feelings (copyright © Deathbulge 2013)<span label="f:performance-feedback-feelings"></span></figcaption>
+<img src="figures/deathbulge-jerk.jpg" alt="Feedback feelings (copyright © Deathbulge 2013)" /><figcaption>Feedback feelings (copyright © Deathbulge 2013)<span label="f:performance-feedback-feelings"></span></figcaption>
 </figure>
 <p>Feedback is easier to give and receive when both parties share expectations about what is and isn’t in scope and about how comments ought to be phrased. If you are the person asking for feedback:</p>
 <dl>
@@ -1645,7 +1646,7 @@ If &quot;string&quot; refers to a datatype, capitalize the &#39;s&#39;!</code></
 </dl>
 <p>Taking notes is more efficient when you have some kind of rubric so that you’re not scrambling to write your observations while the person you’re observing is still talking. The simplest rubric for free-form comments from a group is a 2x2 grid whose vertical axis is labeled “what went well” and “what can be improved”, and whose horizontal axis is labeled “content” (what was said) and “presentation” (how it was said). Observers write their comments on sticky notes as they watch the demonstration, then post those in the quadrants of a grid drawn on a whiteboard (Figure <a href="#f:performance-rubric" data-reference-type="ref" data-reference="f:performance-rubric">[f:performance-rubric]</a>).</p>
 <figure>
-<img src="figures/2x2-rubric.svg" id="f:performance-rubric" /><figcaption>Teaching rubric<span label="f:performance-rubric"></span></figcaption>
+<img src="figures/2x2-rubric.svg" /><figcaption>Teaching rubric<span label="f:performance-rubric"></span></figcaption>
 </figure>
 <blockquote>
 <h4 id="rubrics-and-question-budgets" class="unnumbered unnumbered">Rubrics and Question Budgets</h4>
@@ -1706,7 +1707,7 @@ If &quot;string&quot; refers to a datatype, capitalize the &#39;s&#39;!</code></
 <p>The <a href="http://csteachingtips.org/">CS Teaching Tips</a> site has a large number of practical tips on teaching computing, as well as a collection of downloadable tip sheets. Go through their tip sheets in small groups and classify each tip according to whether you use it all the time, use it occasionally, or never use it. Where do your practice and your peers’ practice differ? Are there any tips you strongly disagree with or think would be ineffective?</p>
 <h2 id="review-4" class="unnumbered unnumbered">Review</h2>
 <figure>
-<img src="figures/conceptmap-feedback.svg" id="f:performance-feedback" /><figcaption>Concepts: Feedback<span label="f:performance-feedback"></span></figcaption>
+<img src="figures/conceptmap-feedback.svg" /><figcaption>Concepts: Feedback<span label="f:performance-feedback"></span></figcaption>
 </figure>
 <h1 id="s:classroom">In the Classroom</h1>
 <p>The previous chapter described how to practice lesson delivery and described one method—live coding—that allows teachers to adapt to their learners’ pace and interests. This chapter describes other practices that are also useful in programming classes.</p>
@@ -1788,7 +1789,7 @@ If &quot;string&quot; refers to a datatype, capitalize the &#39;s&#39;!</code></
 <p>The more you know about your learners before you start teaching, the more you will be able to help them. Inside a formal school system, the prerequisites to your course will tell you something about what they’re likely to already know. In a free-range setting, though, your learners may be much more diverse, so you may want to give them a short survey or questionnaire in advance of your class to find out what knowledge and skills they have.</p>
 <p>Asking people to rate themselves on a scale from 1 to 5 is pointless because the less people know about a subject, the less accurately they can estimate their knowledge (Figure <a href="#f:classroom-dunning-kruger" data-reference-type="ref" data-reference="f:classroom-dunning-kruger">[f:classroom-dunning-kruger]</a>, from <a href="Neurologica">https://theness.com/neurologicablog/index.php/misunderstanding-dunning-kruger/</a>), a phenomenon called the <a href="#g:dunning-kruger-effect"><strong>Dunning-Kruger effect</strong></a> [<a class="cite" href="#ref-Krug1999">Krug1999</a>]. Conversely, people who are members of underrepresented groups will often underrate their skills.</p>
 <figure>
-<img src="figures/dunning-kruger.png" alt="The Dunning-Kruger Effect" id="f:classroom-dunning-kruger" /><figcaption>The Dunning-Kruger Effect<span label="f:classroom-dunning-kruger"></span></figcaption>
+<img src="figures/dunning-kruger.png" alt="The Dunning-Kruger Effect" /><figcaption>The Dunning-Kruger Effect<span label="f:classroom-dunning-kruger"></span></figcaption>
 </figure>
 <p>Rather than asking people to self-assess, you can ask them how easily they could complete some specific tasks. Doing this is risky, though, because school trains people to treat anything that looks like an exam as something they have to pass rather than as a chance to shape instruction. If someone answers “I don’t know” to even a couple of questions on your pre-assessment, they might conclude that your class is too advanced for them. You could therefore scare off many of the people you most want to help.</p>
 <p>Section <a href="#s:checklists-preassess" data-reference-type="ref" data-reference="s:checklists-preassess">21.5</a> presents a short pre-assessment questionnaire that most potential learners are unlikely to find intimidating. If you use it or anything like it, try to follow up with people who <em>don’t</em> respond to find out why not and compare your evaluation of learners with their self-assessment to improve your questions.</p>
@@ -1989,7 +1990,7 @@ If &quot;string&quot; refers to a datatype, capitalize the &#39;s&#39;!</code></
 <h2 id="s:motivation-authentic">Authentic Tasks</h2>
 <p>As Dylan Wiliam points out in [<a class="cite" href="#ref-Hend2017">Hend2017</a>], motivation doesn’t always lead to achievement, but achievement almost always leads to motivation: learners’ success motivates them far more than being told how wonderful they are. We can use this idea in teaching by creating a grid whose axes are “mean time to master” and “usefulness once mastered” (Figure <a href="#f:motivation-what" data-reference-type="ref" data-reference="f:motivation-what">[f:motivation-what]</a>).</p>
 <figure>
-<img src="figures/what-to-teach.svg" id="f:motivation-what" /><figcaption>What to teach<span label="f:motivation-what"></span></figcaption>
+<img src="figures/what-to-teach.svg" /><figcaption>What to teach<span label="f:motivation-what"></span></figcaption>
 </figure>
 <p>Things that are quick to master and immediately useful should be taught first, even if they aren’t considered fundamental by people who are already competent practitioners, because a few early wins will build learners’ confidence in themselves and their teacher. Conversely, things that are hard to learn and aren’t useful to your learners at their current stage of development should be skipped entirely, while topics along the diagonal need to be weighed against each other.</p>
 
@@ -2126,7 +2127,7 @@ If &quot;string&quot; refers to a datatype, capitalize the &#39;s&#39;!</code></
 <h2 id="s:motivation-inclusivity">Inclusivity</h2>
 <p><a href="#g:inclusivity"><strong>Inclusivity</strong></a> is a policy of including people who might otherwise be excluded or marginalized. In computing, it means making a positive effort to be more welcoming to women, underrepresented racial or ethnic groups, people with various sexual orientations, the elderly, those facing physical challenges, the formerly incarcerated, the economically disadvantaged, and everyone else who doesn’t fit Silicon Valley’s affluent white/Asian male demographic. Figure <a href="#f:motivation-women-in-cs" data-reference-type="ref" data-reference="f:motivation-women-in-cs">[f:motivation-women-in-cs]</a> (from <a href="https://www.npr.org/sections/money/2014/10/21/357629765/when-women-stopped-coding">NPR</a>) graphically illustrates the effects of computing’s exclusionary culture on women.</p>
 <figure>
-<img src="figures/women-coding.png" alt="Female computer science majors in the US" id="f:motivation-women-in-cs" /><figcaption>Female computer science majors in the US<span label="f:motivation-women-in-cs"></span></figcaption>
+<img src="figures/women-coding.png" alt="Female computer science majors in the US" /><figcaption>Female computer science majors in the US<span label="f:motivation-women-in-cs"></span></figcaption>
 </figure>
 <p>[<a class="cite" href="#ref-Lee2017">Lee2017</a>] is a brief, practical guide to doing that with references to the research literature. The practices it describes help learners who belong to one or more marginalized or excluded groups, but help motivate everyone else as well. They are phrased in terms of term-long courses, but many can be applied in workshops and other free-range settings:</p>
 <dl>
@@ -2164,7 +2165,7 @@ If &quot;string&quot; refers to a datatype, capitalize the &#39;s&#39;!</code></
 <h3 id="moving-past-the-deficit-model" class="unnumbered unnumbered">Moving Past the Deficit Model</h3>
 <p>Depending on whose numbers you trust, only 12–18% of people getting computer science degrees are women, which is less than half the percentage seen in the mid-1980s (Figure <a href="#f:motivation-gender" data-reference-type="ref" data-reference="f:motivation-gender">[f:motivation-gender]</a>, from [<a class="cite" href="#ref-Robe2017">Robe2017</a>]). And western countries are the odd ones for having such low percentage of women in computing: women are still often 30–40% of computer science students elsewhere [<a class="cite" href="#ref-Galp2002">Galp2002</a>,<a class="cite" href="#ref-Varm2015">Varm2015</a>].</p>
 <figure>
-<img src="figures/enrollment.png" alt="Degrees awarded and female enrollment" id="f:motivation-gender" /><figcaption>Degrees awarded and female enrollment<span label="f:motivation-gender"></span></figcaption>
+<img src="figures/enrollment.png" alt="Degrees awarded and female enrollment" /><figcaption>Degrees awarded and female enrollment<span label="f:motivation-gender"></span></figcaption>
 </figure>
 <p>Since it’s unlikely that women have changed drastically in the last 30 years, we have to look for structural causes to understand what’s gone wrong and how to fix it. One explanation is the way that home computers were marketed as “boys’ toys” starting in the 1980s [<a class="cite" href="#ref-Marg2003">Marg2003</a>]; another is the way that computer science departments responded to explosive growth in enrollment in the 1980s and again in the 2000s by changing admission requirements [<a class="cite" href="#ref-Robe2017">Robe2017</a>]. None of these factors may seem dramatic to people who aren’t affected by them, but they act like the steady drip of water on a stone: over time, they erode motivation, and with it, participation.</p>
 <p>The first and most important step toward fixing this is to stop thinking in terms of a “leaky pipeline” [<a class="cite" href="#ref-Mill2015">Mill2015</a>]. More generally, we need to move past a <a href="#g:deficit-model"><strong>deficit model</strong></a>, i.e. to stop thinking that the members of underrepresented groups lack something and are therefore responsible for not getting ahead. Believing that puts the burden on people who already have to do extra work to overcome structural inequities and (not coincidentally) gives those who benefit from the current arrangements an excuse not to look at themselves too closely.</p>
@@ -2210,7 +2211,7 @@ If &quot;string&quot; refers to a datatype, capitalize the &#39;s&#39;!</code></
 <p>Over the years, I have had a projector catch fire, a student go into labor, and a fight break out in class. I’ve fallen off stage twice, fallen asleep in one of my own lectures, and had many jokes fall flat. In small groups, make up a list of the worst things that have happened to you while you were teaching, then share with the class. Keep the list to remind yourself later that no matter how bad class was, at least none of <em>that</em> happened.</p>
 <h2 id="review-5" class="unnumbered unnumbered">Review</h2>
 <figure>
-<img src="figures/conceptmap-motivation.svg" id="f:motivation-concepts" /><figcaption>Concepts: Motivation<span label="f:motivation-concepts"></span></figcaption>
+<img src="figures/conceptmap-motivation.svg" /><figcaption>Concepts: Motivation<span label="f:motivation-concepts"></span></figcaption>
 </figure>
 <h1 id="s:online">Teaching Online</h1>
 <blockquote>
@@ -2284,7 +2285,7 @@ If &quot;string&quot; refers to a datatype, capitalize the &#39;s&#39;!</code></
 <p>A prominent feature of most MOOCs is their use of recorded video lectures. These can be effective: as mentioned in Chapter <a href="#s:performance" data-reference-type="ref" data-reference="s:performance">8</a>, a teaching technique called Direct Instruction based on precise delivery of a well-designed script has repeatedly been shown to be effective [<a class="cite" href="#ref-Stoc2018">Stoc2018</a>]. However, scripts for direct instruction have to be designed, tested, and refined very carefully, which is an investment that many MOOCs have been unwilling or unable to make. Making a small change to a web page or a slide deck only takes a few minutes; making even a small change to a short video takes an hour or more, so the cost to the teacher of acting on feedback can be unsupportable. And even when they’re well made, videos have to be combined with activities to be beneficial:[<a class="cite" href="#ref-Koed2015">Koed2015</a>] estimated, “<span>…</span>the learning benefit from extra doing<span>…</span>to be more than six times that of extra watching or reading.”</p>
 <p>If you are teaching programming, you may use screencasts instead of slides, since they offer some of the same advantages as live coding (Section <a href="#s:performance-live" data-reference-type="ref" data-reference="s:performance-live">8.1</a>).[<a class="cite" href="#ref-Chen2009">Chen2009</a>] offers useful tips for creating and critiquing screencasts and other videos; Figure <a href="#f:online-screencasting" data-reference-type="ref" data-reference="f:online-screencasting">[f:online-screencasting]</a> (from[<a class="cite" href="#ref-Chen2009">Chen2009</a>]) reproduces the patterns that paper presents and the relationships between them. (It’s also a good example of a concept map (Section <a href="#s:memory-concept-maps" data-reference-type="ref" data-reference="s:memory-concept-maps">3.1</a>).)</p>
 <figure>
-<img src="figures/screencast.svg" id="f:online-screencasting" /><figcaption>Patterns for screencasting<span label="f:online-screencasting"></span></figcaption>
+<img src="figures/screencast.svg" /><figcaption>Patterns for screencasting<span label="f:online-screencasting"></span></figcaption>
 </figure>
 <p>So what makes an instructional video effective?[<a class="cite" href="#ref-Guo2014">Guo2014</a>] measured engagement by looking at how long learners watched MOOC videos, and found that:</p>
 <ul>
@@ -2564,7 +2565,7 @@ for v in values:
 <p>Figure <a href="#f:exercises-labeling" data-reference-type="ref" data-reference="f:exercises-labeling">[f:exercises-labeling]</a> shows how a small fragment of HTML is represented in memory. Put the labels 1–9 on the elements of the tree to show the order in which they are reached in a depth-first traversal.</p>
 </blockquote>
 <figure>
-<img src="figures/labeling.svg" id="f:exercises-labeling" /><figcaption>Labeling a diagram<span label="f:exercises-labeling"></span></figcaption>
+<img src="figures/labeling.svg" /><figcaption>Labeling a diagram<span label="f:exercises-labeling"></span></figcaption>
 </figure>
 <p>Another way to use diagrams is to give learners the pieces of the diagram and ask them to arrange them correctly. This is a visual equivalent of a Parsons Problem, and you can provide as much or as little of a skeleton to help with placement as you think they’re ready for. I have fond memories of trying to place resistors and capacitors in a circuit diagram in order to get the right voltage at a certain point, and have seen teachers give learners a fixed set of Scratch blocks and ask them to create a particular drawing using only those blocks.</p>
 <p><em>Matching problems</em> can be thought of as a special case of labeling in which the “diagram” is a column of text and the labels are taken from the other column. <em>One-to-one matching</em> gives the learner two lists of equal length and asks them to pair corresponding items, e.g. “match each piece of code with the output it produces.”</p>
@@ -2573,7 +2574,7 @@ for v in values:
 <p>Match each regular expression operator in Figure <a href="#f:exercises-matching" data-reference-type="ref" data-reference="f:exercises-matching">[f:exercises-matching]</a> with what it does.</p>
 </blockquote>
 <figure>
-<img src="figures/matching.svg" id="f:exercises-matching" /><figcaption>Matching items<span label="f:exercises-matching"></span></figcaption>
+<img src="figures/matching.svg" /><figcaption>Matching items<span label="f:exercises-matching"></span></figcaption>
 </figure>
 <p>With <em>many-to-many matching</em> the lists aren’t the same length, so some items may be matched to several others and others may not be matched at all. Many-to-many are more difficult because learners can’t do easy matches first to reduce their search space. Matching problems can be implemented by having learners submit lists of matching pairs (such as “A3, B1, C2”), but that’s clumsy and error-prone. Having them recognize a set of correct pairs in an MCQ is even worse, as it’s painfully easy to misread. Drawing or dragging works much better, but may require some work to implement.</p>
 <p><em>Ranking</em> is a special case of matching that is (slightly) more amenable to answering via lists, since our minds are pretty good at detecting errors or anomalies in sequences. The ranking criteria determine the level of reasoning required. If you have learners order sorting algorithms from fastest to slowest you are probably exercising recall (i.e. asking them recognizing the algorithms’ names and know their properties), while asking them to rank solutions from most robust to most brittle exercises reasoning and judgment.</p>
@@ -4195,18 +4196,18 @@ Help who you can.</p>
 <h1 id="s:conceptmaps">Example Concept Maps</h1>
 <p>These concept maps were created by Amy Hodge of Stanford University, and are re-used with permission.</p>
 <figure>
-<img src="figures/library-patron-concept-map.svg" id="f:conceptmaps-library-patron" /><figcaption>Library patron concept map<span label="f:conceptmaps-library-patron"></span></figcaption>
+<img src="figures/library-patron-concept-map.svg" /><figcaption>Library patron concept map<span label="f:conceptmaps-library-patron"></span></figcaption>
 </figure>
 <figure>
-<img src="figures/library-director-concept-map.svg" id="f:conceptmaps-library-director" /><figcaption>Library director concept map<span label="f:conceptmaps-library-director"></span></figcaption>
+<img src="figures/library-director-concept-map.svg" /><figcaption>Library director concept map<span label="f:conceptmaps-library-director"></span></figcaption>
 </figure>
 <figure>
-<img src="figures/library-friends-concept-map.svg" id="f:conceptmaps-library-friends" /><figcaption>Library friends concept map<span label="f:conceptmaps-library-friends"></span></figcaption>
+<img src="figures/library-friends-concept-map.svg" /><figcaption>Library friends concept map<span label="f:conceptmaps-library-friends"></span></figcaption>
 </figure>
 <h1 id="s:chunking">Chunking Exercise Solution</h1>
 <p>See the last exercise in Chapter <a href="#s:memory" data-reference-type="ref" data-reference="s:memory">3</a> for the unchunked representation of these symbols.</p>
 <figure>
-<img src="figures/chunking-chunked.svg" id="f:chunking-chunked" /><figcaption>Chunked representation<span label="f:chunking-chunked"></span></figcaption>
+<img src="figures/chunking-chunked.svg" /><figcaption>Chunked representation<span label="f:chunking-chunked"></span></figcaption>
 </figure>
 <h1 id="references" class="unnumbered unnumbered">References</h1>
 
@@ -5121,6 +5122,9 @@ Help who you can.</p>
 <div id="ref-Solo1984">
 <p><strong>[Solo1984]</strong> Soloway, Elliot, and Kate Ehrlich. “Empirical Studies of Programming Knowledge.” <em>IEEE Transactions on Software Engineering</em> SE-10, no. 5 (September 1984): 595–609. doi:<a href="https://doi.org/10.1109/tse.1984.5010283">10.1109/tse.1984.5010283</a>. Proposes that experts have programming plans and rules of programming discourse.</p>
 </div>
+<div id="ref-Sond2012">
+<p><strong>[Sond2012]</strong> Søndergaard, Harald, and Raoul A. Mulder. “Collaborative Learning Through Formative Peer Review: Pedagogy, Programs and Potential.” <em>Computer Science Education</em> 22, no. 4 (December 2012): 343–67. doi:<a href="https://doi.org/10.1080/08993408.2012.728041">10.1080/08993408.2012.728041</a>. Surveys literature on student peer assessment, distinguishing grading and reviewing as separate forms, and summarizes features a good peer review system needs to have.</p>
+</div>
 <div id="ref-Sorv2018">
 <p><strong>[Sorv2018]</strong> Sorva, Juha. “Misconceptions and the Beginner Programmer.” In <em>Computer Science Education: Perspectives on Teaching and Learning in School</em>, edited by Sue Sentance, Erik Barendsen, and Carsten Schulte. Bloomsbury Press, 2018. Summarizes what we know about what novices misunderstand about computing.</p>
 </div>
@@ -5186,9 +5190,6 @@ Help who you can.</p>
 </div>
 <div id="ref-Sved2016">
 <p><strong>[Sved2016]</strong> Svedin, Maria, and Olle Bälter. “Gender Neutrality Improved Completion Rate for All.” <em>Computer Science Education</em> 26, nos. 2-3 (July 2016): 192–207. doi:<a href="https://doi.org/10.1080/08993408.2016.1231469">10.1080/08993408.2016.1231469</a>. Reports that redesigning an online course to be gender neutral improves completion probability in general, but decreases it for students with a superficial approach to learning.</p>
-</div>
-<div id="ref-Sond2012">
-<p><strong>[Sond2012]</strong> Søndergaard, Harald, and Raoul A. Mulder. “Collaborative Learning Through Formative Peer Review: Pedagogy, Programs and Potential.” <em>Computer Science Education</em> 22, no. 4 (December 2012): 343–67. doi:<a href="https://doi.org/10.1080/08993408.2012.728041">10.1080/08993408.2012.728041</a>. Surveys literature on student peer assessment, distinguishing grading and reviewing as separate forms, and summarizes features a good peer review system needs to have.</p>
 </div>
 <div id="ref-Tedr2008">
 <p><strong>[Tedr2008]</strong> Tedre, Matti, and Erkki Sutinen. “Three Traditions of Computing: What Educators Should Know.” <em>Computer Science Education</em> 18, no. 3 (September 2008): 153–70. doi:<a href="https://doi.org/10.1080/08993400802332332">10.1080/08993400802332332</a>. Summarizes the history and views of three traditions in computing: mathematical, scientific, and engineering.</p>
@@ -5666,6 +5667,7 @@ Help who you can.</p>
 <li id="fn377"><p>Wiggins and McTighe, <em>Understanding by Design</em>; Biggs and Tang, <em>Teaching for Quality Learning at University</em>; Fink, <em>Creating Significant Learning Experiences</em>.<a href="#fnref377" class="footnote-back">↩</a></p></li>
 </ol>
 </section>
+      </div>
     </div>
   </div>
 </div>

--- a/template.html
+++ b/template.html
@@ -46,8 +46,8 @@ $for(include-before)$
 $include-before$
 $endfor$
 <div class="container-fluid">
-  <div class="row row-scrollable">
-    <div class="col-md-2 col-toc">
+  <div class="row">
+    <nav class="col-md-2 col-toc">
       <a href="#title-block-header"><img src="assets/logo.svg" alt="Teaching Tech Together" width="100%" /></a>
 $if(toc)$
 <nav id="$idprefix$TOC" role="doc-toc">
@@ -59,39 +59,41 @@ $table-of-contents$
         <a href="https://github.com/gvwilson/teachtogether.tech/"><img src="assets/github.svg" alt="GitHub" width="20%" /></a>
       </p>
 $endif$
-    </div>
-    <div class="col-md-8 col-body">
-      <header>
-        <h1 class="title">$title$</h1>
-        $if(subtitle)$
-        <p class="subtitle">$subtitle$</p>
-        $endif$
-        $for(author)$
-        <p class="author"><a href="http://third-bit.com">$author$</a></p>
-        $endfor$
-        $if(date)$
-        <p class="date">$date$</p>
-        $endif$
-      </header>
-      <div class="dedication">
-        <p><strong>Dedication</strong></p>
-        <p>
-          For my mother, Doris Wilson,<br/>
-          who taught hundreds of children to read and to believe in themselves.<br/>
-        </p>
-        <p>
-          And for my brother Jeff, who did not live to see it finished.<br/>
-          "Remember, you still have a lot of good times in front of you."<br/>
-        </p>
-        <p>
-          All royalties from the sale of this book are being donated to<br/>
-          the Carpentries,<br/>
-          a volunteer organization that teaches<br/>
-          foundational coding and data science skills<br/>
-          to researchers worldwide.
-        </p>
-      </div>
+    </nav>
+    <div class="col-md-10 col-body">
+      <div class="container">
+        <header>
+          <h1 class="title">$title$</h1>
+          $if(subtitle)$
+          <p class="subtitle">$subtitle$</p>
+          $endif$
+          $for(author)$
+          <p class="author"><a href="http://third-bit.com">$author$</a></p>
+          $endfor$
+          $if(date)$
+          <p class="date">$date$</p>
+          $endif$
+        </header>
+        <div class="dedication">
+          <p><strong>Dedication</strong></p>
+          <p>
+            For my mother, Doris Wilson,<br/>
+            who taught hundreds of children to read and to believe in themselves.<br/>
+          </p>
+          <p>
+            And for my brother Jeff, who did not live to see it finished.<br/>
+            "Remember, you still have a lot of good times in front of you."<br/>
+          </p>
+          <p>
+            All royalties from the sale of this book are being donated to<br/>
+            the Carpentries,<br/>
+            a volunteer organization that teaches<br/>
+            foundational coding and data science skills<br/>
+            to researchers worldwide.
+          </p>
+        </div>
 $body$
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
- Use position: sticky for sidebar. This way the whole document is
  scrollable instead of having scrollable parts, and makes internal
  links (with #anchors) behave correctly.

- Make the sidebar collapse correctly on smaller screens.

- Implement layout width limit for main content using .container
  instead of .col-md-8. This makes it behave correctly on mobile.