### PR TITLE
Typo on README.md

### DIFF
--- a/es/README.md
+++ b/es/README.md
@@ -90,7 +90,7 @@ Ejemplo:
 
 | Inglés                | Español                           |
 | ----------------------|-----------------------------------|
-| bournout/bourning out | síndrome de desgaste ocupacional  |
+| burnout/burning out | síndrome de desgaste ocupacional  |
 | competent practitioners| practicantes competentes, personas competentes |
 | call stack | pila de llamada |
 | chunking | particionar, fragmentar |


### PR DESCRIPTION
"burnout" - there was a typo, detected by Malena Zabalegui (I've shared this information with her)