### PR TITLE
traduccion de outreach.tex

### DIFF
--- a/es/outreach.tex
+++ b/es/outreach.tex
@@ -1,826 +1,848 @@
-\chapter{Outreach}\label{s:outreach}
+\chapter{Difusión}\label{s:outreach}
 
-It's fashionable in tech circles
-to disparage universities and government institutions as slow-moving dinosaurs,
-but in my experience they are no worse than companies of similar size.
-Your local school board, library, and your city councilor's office
-may be able to offer space, funding, publicity,
-connections with other groups that you may not have met yet,
-and a host of other useful things;
-getting to know them can help you solve or avoid problems in the short term
-and pay dividends down the road.
+Está de moda en los círculos tecnológicos menospreciar a las universidades y las
+instituciones gubernamentales como si fueran dinosaurios lentos, pero en mi experiencia no son peores que empresas de tamaño similar.
+Tanto la junta del consejo escolar (NOTA:sé que existe algo como school board pero no se si cumple el mismo rol que el consejo escolar), 
+la biblioteca o la oficina del concejal de la ciudad puede llegar a ofrecer espacio, fondos, publicidad, conexiones con otros grupos que 
+todavía no hayas conocido y una gran cantidad de cosas útiles; conocerlas puede ayudar
+a resolver o evitar problemas en el corto plazo y generar beneficios en el futuro.
 
 \seclbl{Marketing}{s:outreach-marketing}
 
-People with academic or technical backgrounds often think that
-\gref{g:marketing}{marketing} is about spin and misdirection.
-In reality,
-it's about seeing things from other people's perspective,
-understanding their wants and needs,
-and explaining how you can help them---in short,
-how to teach them.
-This chapter will look at how to use ideas from the previous chapters
-to get people to understand and support what you're doing.
+Las personas con conocimientos académicos y técnicos muchas veces piensan que
+el  \gref{g:marketing}{marketing} trata sobre confundir y engañar. 
+En la realidad, trata sobre ver cosas desde la perspectiva de otras personas,
+comprendiendo sus deseos y necesidades, y explicando cómo puedes ayudarles---en pocas palabras, cómo enseñarles.
+Este capítulo analizará cómo usar ideas de los capítulos anteriores
+para lograr que las personas entiendan y apoyen lo que estás haciendo.
 
-The first step is to figure out what you are offering to whom,
-i.e.\ what actually brings in the volunteers,
-funding,
-and other support you need to keep going.
-The answer is often counter-intuitive.
-For example,
-most scientists think their papers are their product,
-but it's actually their grant proposals,
-because those are what brings in grant money~\cite{Kuch2011}.
-Their papers are the advertising that persuades people to fund those proposals,
-just as albums are now what persuades people to buy musicians' concert tickets and t-shirts.
+El primer paso es averiguar qué es lo que le ofreces a quién, es decir, 
+lo que realmente atrae a los voluntarios, a los fondos 
+y otro tipo de apoyo que puedas necesitar para continuar.
+La respuesta generalmente es contraintuitiva.
+Por ejemplo, la mayoría de los científicos creen que sus productos son sus artículos,
+cuando en realidad son sus propuestas de subsidios, 
+ya que son éstos los que atraen el dinero del subsidio~\cite{Kuch2011}.
+Los artículos son la publicidad que convence a otras personas para otorgarle fondos a las propuestas, 
+así como ahora los álbumes son los que convencen a la gente a comprar tickets para el show y remeras del músico que van a ver.
 
-Suppose that your group offers weekend programming workshops
-to people who are re-entering the workforce after being away for several years.
-If workshop participants can pay enough to cover your costs,
-then they are your customers and the workshops are the product.
-If,
-on the other hand,
-the workshops are free or the learners are only paying a token amount to cut the no-show rate,
-then your actual product may be some mix of:
+Suponiendo que tu grupo ofrece talleres de programación de fin de semana
+a personas que están re-insertándose en la fuerza de trabajo después de haber estado alejadas por varios años.
+Si los asistentes pueden pagar lo suficiente para cubrir tus costos,
+entonces son tus clientes y el taller es tu producto. 
+Si por otro lado, los talleres son gratuitos o los estudiantes solo pagan un monto simbólico para reducir la tasa de ausencias,
+entonces tu producto real puede ser una mezcla de:
 
 \begin{itemize}
 
 \item
-  your grant proposals;
+   tus proyectos de subsidio;
 
 \item
-  the alumni of your workshops
-  that the companies sponsoring you would like to hire;
+ los antiguos alumnos de tus talleres
+a los que las empresas  que te patrocinaron quisieran contratar;
 
 \item
-  the half-page summary of your workshops in the mayor's annual report to city council
-  that shows how she's supporting the local tech sector;
-  or
+el resumen de media página de tus talleres en el balance anual de tu intendente/alcalde al concejo deliberante
+que muestra cómo ella apoya el sector tecnológico local;
 
 \item
-  the personal satisfaction that volunteers get from teaching.
+     la satisfacción personal que obtienen los voluntarios cuando enseñan
 
 \end{itemize}
 
-As with lesson design (\chapref{s:process}),
-the first steps in marketing are
-to create personas\index{learner persona}
-of people who might be interested in what you're doing
-and to figure out which of their needs you can meet.
-One way to summarize the latter is to write \grefdex{g:elevator-pitch}{elevator pitches}{elevator pitch}
-aimed at different personas.
-A widely used template for these is:
+Tal como con el diseño de  lecciones (\chapref{s:process}),
+los primeros pasos en marketing son crear
+el equivalente a estudiantes tipo\index{learner persona},
+gente que podría estar interesada en lo que estás haciendo 
+y averiguar cuáles de sus necesidades puedes satisfacer.
+Una manera de resumir lo último es escribir \grefdex{g:elevator-pitch}{discursos de presentación}{discurso de presentación} 
+dirigido a diferentes personas.
+Una plantilla muy usada para esto es:
+
 
 \newpage
 \begin{longtable}{ll}
-  For 		& \emph{target audience} \\
-  who 		& \emph{dissatisfaction with what's currently available} \\
-  our 		& \emph{category} \\
-  provide 	& \emph{key benefit}. \\
-  Unlike 	& \emph{alternatives} \\
-  our program 	& \emph{key distinguishing feature.}
+  Para        & \emph{ objetivo de audiencia} \\
+  quien        & \emph{ insatisfacción con lo que se encuentra actualmente disponible} \\
+  nosotros        & \emph{categoría} \\
+  provee    & \emph{beneficio clave}. \\
+  a diferencia de    & \emph{alternativas} \\
+  nuestro programa    & \emph{característica distintiva clave}
+
 \end{longtable}
 
 \noindent
-Continuing the weekend workshop example,
-we could use this pitch for participants:
+Continuando con el ejemplo del taller de fin de semana,
+se podría usar este discurso para los participantes
+
 
 \begin{quote}
 
-  For \emph{people re-entering the workforce after being away for several years}
-  who \emph{still have family responsibilities},
-  our \emph{introductory programming workshops}
-  provide \emph{weekend classes with on-site childcare}.
-  Unlike \emph{online classes},
-  our program \emph{gives people a chance to meet others at the same stage of life}.
+quienes \emph{tienen todavía responsabilidades familiares },
+nuestros \emph{talleres introductorios de programación}
+provee \emph{clases en fin de semana con guardería incluida}.
+A diferencia de emph{clases en línea},
+nuestro programa \emph{ le da a la gente la oportunidad de conocer
+a otras personas en el misma etapa de la vida}.
+
 
 \end{quote}
 
 \noindent
-and this one for decision makers at companies that might sponsor the workshops:
+y ésta otra para los tomadores de decisiones en las empresas que podrían patrocinar los talleres:
 
 \begin{quote}
 
-  For \emph{companies that want to recruit entry-level software developers}
-  that \emph{struggle to find mature candidates from diverse backgrounds}
-  our \emph{introductory programming workshops}
-  provide \emph{potential recruits}.
-  Unlike \emph{college recruiting fairs},
-  our program \emph{connects companies with a wide variety of candidates}.
+ Para\emph{empresas que quieren reclutar desarrolladores de software de nivel básico}
+  que \emph{ tienen dificultades para  encontrar candidatos con suficiente madurez  de diversas formaciones}
+  nuestros \emph{ talleres introductorios de programación}
+  proveen de\emph{potenciales reclutas}.
+  A diferencia de \emph{ feria de reclutamiento universitario},
+  nuestro programa \emph{ conecta empresas con una gran variedad de candidato/ass}.
+
 
 \end{quote}
 
-If you don't know why different potential stakeholders might be interested in what you're doing,
-ask them.
-If you do know,
-ask them anyway:
-answers can change over time,
-and you may discover things you previously overlooked.
+Si no sabes por qué diferentes potenciales accionistas pueden estar interesados en los que haces,
+preguntales.
+Si lo sabes,
+preguntales igual:
+las respuestas cambian con el tiempo,
+y pueden descubrir cosas que no habías notado antes
 
-Once you have these pitches,
-they should drive what you put on your website and in publicity material
-to help people figure out as quickly as possible
-if you and they have something to talk about.
-(You probably \emph{shouldn't} copy them verbatim,
-though:
-many people in tech have seen this template so often that
-their eyes will glaze over if they encounter it again.)
+Una vez que tienes estas discursos,
+estos deberían llevarlos a lo que se publique en el sitio web y el material de difusión
+para ayudar a la gente para ayudar a las personas a descubrir lo más rápido posible
+si tu y ellos tienen algo de qué hablar
+( \emph{No deberías} copiarlos textualmente,
+aunque:
+muchas personas en tecnología han visto esta plantilla tan seguido que 
+sus ojos se podrán vidriosos si la vuelven a encontrar.)
 
-As you are writing these pitches,
-remember that there are many reasons to learn how to program
+
+
+Mientras escribes estos discursos
+recuerda que hay varias razones para aprender cómo programar
 (\secref{s:intro-exercises}).
-A sense of accomplishment,
-control over their own lives,
-and being part of a community may motivate people more than money
+Una sensación de logro,
+control sobre sus propias vidas,
+y ser parte de una comunidad puede motivar a las personas más que el dinero
 (\chapref{s:motivation}).
-They might volunteer to teach with you because their friends are doing it;
-similarly,
-a company may say that they're sponsoring classes for economically disadvantaged high school students
-because they want a larger pool of potential employees further down the road,
-but the CEO might actually be doing it simply because it's the right thing to do.
+Podrían ofrecerse como voluntarios para enseñar contigo  porque sus amigos lo están haciendo;
+ de igual manera,
+ una empresa puede decir que está patrocinando clases para estudiantes de secundaria que estén desfavorecidos económicamente
+ porque quieren tener un grupo más grande de empleados potenciales en el futuro, 
+ pero el CEO podría realmente estar haciéndolo simplemente porque es lo correcto.
 
-\seclbl{Branding and Positioning}{s:outreach-branding}
+\seclbl{Branding y Posicionamiento}{s:outreach-branding}
 
-A \gref{g:brand}{brand} is someone's first reaction to a mention of a product;
-if the reaction is ``what's that?'',
-you don't have a brand (yet).
-Branding is important because
-people aren't going to help something they don't know about or don't care about.
+Una \gref{g:brand}{marca} es la primera reacción de una persona a la mención de un producto;
+Si ante la primera reacción de la mención de un producto;
+la reacción es “¿Que es eso?”,
+uno (todavía) no tiene una marca.
+“ Branding” es importante porque
+la gente no va a ayudar en algo que no conocen o no le interesa/importa.
 
-Most discussion of branding today focuses on
-how to build awareness online.
-Mailing lists,
+La mayor parte de la discusión actual sobre “branding” se enfoca 
+en como crear conciencia en línea.
+Listas de correo,
 blogs,
-and Twitter all give you ways to reach people,
-but as the volume of misinformation increases,
-people pay less attention to each individual interruption.
-This makes \gref{g:positioning}{positioning} ever more important.
-Sometimes called ``differentiation,''
-it is what sets your offering apart from others---the ``unlike'' section of your elevator pitches.
-When you reach out to people who are already familiar with your field,
-you should emphasize your positioning,
-since it's what will catch their attention.
+y Twitter, todos generan maneras de llegar a la gente,
+pero así como el volumen de desinformación aumenta,
+la gente le presta menos atención a cada interrupción individual.
 
-There are other things you can do to help build your brand.
-One is to use props
-like a robot that one of your learners made from scraps she found around the house~\cite{Schw2013}
-or the website another learner made for his parents' retirement home.
-Another is to make a short video---no more than a few minutes long---that showcases
-the backgrounds and accomplishments of your learners.
-The aim of both is to tell a story:
-while people always ask for data,
-they believe and remember stories.
+Esto hace que el \gref{g:positioning}{posicionamiento} sea más importante.
+Algunas veces llamado “diferenciación”,
+es lo que distingue a tu oferta de las otras, la sección “a diferencia de” de tu “discurso de presentación”.
+Cuando te comunicas con personas que están familiarizadas en tu campo,
+debes enfatizar o hacer hincapié en tu posicionamiento,
+ya que es eso lo que va a llamar su atención.
 
-\begin{aside}{Foundational Myths}
-  One of the most compelling stories a person or group can tell is
-  why and how they got started.
-  Are you teaching what you wish someone had taught you but didn't?
-  Was there one particular person you wanted to help,
-  and that opened the floodgates?
-  If there isn't a section on your website starting, ``Once upon a time,''
-  think about adding one.
+
+Existen otras cosas que puedes hacer para construir tu “marca”
+Una de ellas es usar accesorios como un robot que uno de los estudiantes hizo a partir de restos que encontró en su casa~\cite{Schw2013}
+o el sitio web que otro estudiante hizo para el de geriatrico sus padres.
+
+Otra opción es hacer un video corto-- de no más de un par de minutos de duración--
+que resalte los antecedentes y logros de tus estudiantes.
+El objetivo es tanto contar una historia:
+mientras que la gente siempre pide datos,
+creen y recuerdan historias.
+
+
+\begin{aside}{Mitos Fundacionales}
+ Una de las historias más convincentes que una persona o grupo puede contar es
+por qué y cómo comenzaron.
+¿Estás enseñando algo que quisieras que alguien te hubiera enseñado pero no lo hizo?
+¿Había una persona en particular a la que quisieras ayudar,
+y eso abrió las compuertas?
+
+Si no hay una sección en tu sitio web que comience con “Había una vez,”
+piensa en agregar una.
+
 \end{aside}
 
-One crucial step is to make your organization findable in online searches.\index{findability!of organizations}
-\cite{DiSa2014b} discovered that
-the search terms that parents used for out-of-school computing classes
-didn't actually find those classes,
-and many other groups face similar challenges.
-There's a lot of folklore about how to make things findable
-(otherwise known as \gref{g:seo}{search engine optimization} or SEO);
-given Google's near-monopoly powers and lack of transparency,
-most of it boils down to trying to stay one step ahead of
-algorithms designed to prevent people from gaming rankings.
+Un paso crucial es lograr que tu organización pueda ser encontrada en las búsquedas en línea .\index{findability!of organizations}
+\cite{DiSa2014b} descubrió que
+los términos de búsqueda que los padres usan para las clases de computación fuera de la escuela de sus hijos
+en realidad no encontraban esas clases,
+y muchos otros grupos se enfrentan a desafíos similares.
+Hay mucho “folklore “ sobre cómo hacer que las cosas puedan ser halladas en internet 
+( también conocido como\gref{g:seo}{Motor de optimización de posicionamiento en buscadores} or SEO);
+dados los  poderes cuasi-monopólicos y falta de transparencia de Google,
+la mayor parte de esto se reduce a tratar de estar un paso adelante de los 
+algoritmos diseñados para alejar a las personas clasifiquen en rankings basados en juegos.
 
-Unless you're very well funded,
-the best you can do is to search for yourself and your organization on a regular basis
-and see what comes up,
-then read \hreffoot{https://moz.com/learn/seo/on-page-factors}{these guidelines}
-and do what you can to improve your site.
-Keep \hreffoot{https://xkcd.com/773/}{this XKCD cartoon} in mind:
-people don't want to know about your org chart or get a virtual tour of your site---they want your address,
-parking information,
-and some idea of what you teach,
-when you teach it,
-and how it's going to change their lives.
+A menos que estés muy bien financiado,
+los mejor que puedes hacer es buscarte y buscar a tu organización frecuentemente
+y ver que surge,
+lee entonces \hreffoot{https://moz.com/learn/seo/on-page-factors}{estas guías}
+y haz lo que puedas para mejorar tu sitio
+A menos que tengas muchos fondos,
+Ten en mente\hreffoot{https://xkcd.com/773/}{esta viñeta de XKCD} :
+la gente no quiere saber sobre el organigrama o un paseo virtual por el sitio-- ellos necesitan tu dirección,
+información sobre donde hay estacionamiento cerca, 
+y alguna idea sobre que enseñas,
+cuando lo enseñas,
+y cómo va a cambiar sus vidas.
 
-\begin{aside}{Not Everyone Lives Online}
-  These examples assume people have access to the internet
-  and that groups have money, materials, free time, and/or technical skills.
-  Many don't---in fact,
-  those serving economically disadvantaged groups almost certainly don't.
-  (As Rosario Robinson says, ``Free works for those that can afford free.'')\index{Robinson, Rosario}
-  Stories are more important than course outlines in those situations
-  because they are easier to retell.
-  Similarly,
-  if the people you hope to reach are not online as often as you,
-  then notice boards in schools,
-  local libraries,
-  drop-in centers,
-  and grocery stores may be the most effective way to reach them.
+
+\begin{aside}{No todo el mundo vive en línea}
+Estos ejemplos asumen que la gente tiene acceso a internet 
+y que los grupos tienen dinero, materiales, tiempo libre, y/o  habilidades técnicas.
+La mayoría no tiene-- de hecho,
+aquellos que trabajan con grupos económicamente desfavorecidos muy probablemente no los tienen.
+ (Como Rosario Robinson dice, ``Gratis funciona para aquellos para quien pueden darse lujo de que sea gratuito.'')\index{Robinson, Rosario}
+Historias son más importantes que el programa del curso en estas situaciones
+porque son más fáciles de volver a contar.
+ De manera similar,
+si las personas que deseas o esperas alcanzar no están tan en línea como tú,
+debes entonces prestar atención a los avisos en las carteleras de las escuelas,
+en bibliotecas locales,
+centro de acogida,
+y almacenes puede ser el camino más efectivo para alcanzarlos.
+
 \end{aside}
 
-\seclbl{The Art of the Cold Call}{s:outreach-cold-call}
+\seclbl{El arte de las llamadas en frío}{s:outreach-cold-call}
 
-Building a website and hoping that people find it is easy;
-calling people up or knocking on their door without any sort of prior introduction
-is much harder.
-As with standing up and teaching,
-though,
-it's a craft that can be learned.
-Here are ten simple rules for talking people into things:
+Crear un sitio web y desear que las personas lo encuentren es fácil;
+llamar por teléfono o golpear en las puertas de sus casa sin ningún tipo de introducción previa
+es más difícil.
+Al igual que pararse y enseñar,
+sin embargo, es un oficio que puede aprenderse.
+ Aquí hay diez reglas simples para convencer a las personas:
+
 
 \begin{description}
 
-\item[1: Don't.]
-  If you have to talk someone into something,
-  odds are that they don't really want to do it.
-  Respect that:
-  it's almost always better in the long run to leave some particular thing undone
-  than to use guilt or any underhanded psychological tricks that will only engender resentment.
+\item[1: No o no lo hagas]
 
-\item[2: Be kind.]
-  I don't know if there actually is a book called
-  \emph{Secret Tricks of the Ninja Sales Masters},
-  but if there is,
-  it probably tells readers that doing something for a potential customer
-  creates a sense of obligation,
-  which in turn increases the odds of a sale.
-  That may work, but it only works once and it's a skeezy thing to do.
-  On the other hand,
-  if you are genuinely kind
-  and help other people because it's what good people do,
-  you just might inspire them to be good people too.
+Si tienes que convencer a alguien de algo,
+lo más probable es que realmente no quieran hacerlo.
+Respeta que:
+es casi siempre mejor en el largo plazo dejar alguna cosa en particular sin terminar
+que usar culpa u otro truco psicológico inescrupuloso que solo generaría resentimiento.
 
-\item[3: Appeal to the greater good.]
-  If you open by talking about what's in it for them,
-  you are signaling that they should think of their interaction with you
-  as a commercial exchange of value to be bargained over.
-  Instead,
-  start by explaining how whatever you want them to help with is going to make the world a better place,
-  and \emph{mean it}.
-  If what you're proposing isn't going to make the world a better place,
-  propose something better.
 
-\item[4: Start small.]
-  Most people are understandably reluctant to dive into things head-first,
-  so give them a chance to test the waters
-  and to get to know you and everyone else involved in
-  whatever it is you want help with.
-  Don't be surprised or disappointed if that's where things end:
-  everyone is busy or tired or has projects of their own,
-  or maybe just has a different mental model of how collaboration is supposed to work.
-  Remember the 90-9-1 rule---90\% of people will watch,
-  9\% will speak up,
-  and 1\% will actually do things---and set your expectations accordingly.
+\item[2: Se amable.]
+No se si realmente existe un libro llamado
+ \emph{Trucos secretos de los maestros de ventas Ninja},
+pero si existe,
+probablemente le dice a sus lectores que hacer algo por un potencial cliente
+crea un sentido de obligación,
+lo que a su vez aumenta las probabilidades de una venta.
+Esto puede funcionar, pero solo funciona una vez y es una cosa medio extraña para hacer.
+Por otra parte,
+si eres genuinamente amable
+y ayudas a otras personas porque eso es lo que las buenas personas hacen,
+puedes tal vez inspirarlos/as a ser buenas personas también.
 
-\item[5: Don't build a project: build a community.]
-  I used to belong to a baseball team that never actually played baseball:
-  our ``games'' were just an excuse for us to hang out and enjoy each other's company.
-  You probably don't want to go quite that far,
-  but sharing a cup of tea with someone or celebrating the birth of their first grandchild
-  can get you things that no reasonable amount of money can.
 
-\item[6: Establish a point of connection.]
-  ``I was speaking to X'' or ``we met at Y'' gives them context,
-  which in turn makes them more comfortable.
-  This must be specific:
-  spammers and cold-callers have trained us all to ignore anything that starts,
-  ``I recently came across your website{\ldots}''
+\item[3: Apela al bien mayor.]
+Si les hablas abiertamente sobre que hay disponible ellos/as,
+estás indicando que deberían pensar en su interacción contigo
+como un  si fuera un intercambio comercial de valor para negociar que debe negociarse.
+En su lugar,
+empieza por explicar cómo lo que sea que queremos que nos ayude puede hacer del mundo un lugar mejor, y en dilo en serio.
+Si lo que estás proponiendo no va a hacer del mundo un lugar mejor,
+propone algo mejor.
 
-\item[7: Be specific about what you are asking for.]
-  People need to know this
-  so that they can figure out whether the time and skills they have
-  are a match for what you need.
-  Being realistic up front is also a sign of respect:
-  if you tell people you need a hand moving a few boxes
-  when you're actually packing up an entire house,
-  they're probably not going to help you a second time.
+\item[4: Comienza desde algo pequeño.]
+Es comprensible que la mayoría de las personas se muestren reacias a sumergirse de lleno en las cosas, 
+así que debes darle  la oportunidad de probar las aguas 
+y conocerte a ti y a todos los demás involucrados
+ en lo que sea en  que necesites ayuda.
+No te sorprendas o decepciones si es así como las cosas terminaron:
+todo el mundo está ocupado o cansado o tiene proyectos propios,
+o tal vez tienen un modelo mental de cómo las colaboraciones deberían funcionar.
+Recuerda la regla  90-9-1-- el 90\% va a mirar,
+el 9\% va a hablar 
+y el 1\% realmente va hacer cosas-- ajusta tus expectativas de modo acorde.
 
-\item[8: Establish your credibility.]
-  Mention your backers,
-  your size,
-  how long your group has been around, or something that you've accomplished in the past
-  so that they'll believe you're worth taking seriously.
+\item[5: No crea un proyecto: crea una comunidad.]
+Solía pertenecer a un equipo de baseball que nunca realmente jugaba al baseball:
+nuestros “ juegos o partidos” eran solo una excusa para pasar tiempo juntos y disfrutar la compañía del otro.
+Probablemente no quieres llegar tan lejos,
+pero compartir una taza de té con alguien o celebrar el cumpleaños de su primer/a nieto/a
+pueden darte cosas que ninguna cantidad de dinero pueden dar
 
-\item[9: Create a slight sense of urgency.]
-  ``We're hoping to launch this in the spring'' is more likely to get a positive response
-  than ``We'd eventually like to launch this.''
-  However, the word ``slight'' is important:
-  if your request is urgent,
-  most people will assume you're disorganized or that something has gone wrong
-  and may then err on the side of prudence.
+\item[6: Establece un punto de conexión.]
+“Estaba hablando con x” o “Nos conocimos en Y” les da contexto,
+lo que a su vez los hace sentir más cómodos.
+Esto debe ser específico:
+quienes envían correo basura y empresas que llaman por teléfono constantemente
+nos han entrenado para ignorar cualquier cosa que comience con la frase
+“ Hace poco tiempo encontré tu sitio web {\ldots}''
+\item[7: Sé específico sobre lo que estás pidiendo.]
 
-\item[10: Take a hint.]
-  If the first person you ask for help says no,
-  ask someone else.
-  If the fifth or the tenth person says no,
-  ask yourself if what you're trying to do makes sense and is worth doing.
+Las personas necesitan saber esto
+para que puedan determinar si el tiempo y las habilidades que tienen
+coinciden con lo que necesitas.
+Ser realista desde el principio también es una señal de respeto:
+ si le dices a la gente que necesitas una mano para  mover algunas cajas
+ cuando en realidad estás mudando una casa entera,
+ probablemente no te ayudarán por segunda vez.
+
+\item[8: Establece tu credibilidad.]
+Menciona a tus patrocinadores,
+tu tamaño,
+cuanto tiempo tu grupo ha existido, o algo que hayas logrado en el pasado
+para que ello/as crea que vale la pena tomarte en serio
+
+
+\item[9: Crea una ligera sensación de urgencia.]
+“Esperamos lanzar esto en la primavera” es mucho más probable que genere una respuesta positiva que “Eventualmente queremos lanzar esto.”
+Sin embargo la palabra “ligera” es importante:
+si tu pedido es urgente, 
+la mayoría de las personas asumen que eres una persona desorganizadas o que algo ha salido mal
+y pueden errar por ser prudentes.
+
+
+\item[10: Entiende la indirecta.]
+Si la primera persona a la que le pides ayuda dice no,
+pregúntale a otra.
+Si la quinta o décima persona dice no,
+debes preguntarte si los que estás tratando de hacer tiene sentido y vale la pena hacerse
 
 \end{description}
 
-The email template below follows all of these rules.
-It has worked pretty well:
-we found that about half of emails were answered,
-about half of those wanted to talk more,
-and about half of those led to workshops,
-which means that 10--15\% of targeted emails turned into workshops.
-That can still be pretty demoralizing if you're not used to it,
-but is much better than the 2--3\% response rate most organizations expect with cold calls.
+Esta plantilla de correo electrónico sigue todas estas reglas.
+Ha funcionado bastante bien:
+hallamos que cerca de la mitad de los correos son respondidos,
+y aproximadamente la mitad de estos querían hablar más,
+y la mitad des estos últimos condujeron a talleres,
+lo que significa que 10-15\% de los correos electrónicos objetivos resultaron en talleres.
+Esto puede ser bastante desmoralizante si no te encuentras acostumbrado a esto, 
+pero es mucho mejor que la tasa de respuesta de entre  2--3\% que la mayoría de las organizaciones esperan con llamadas imprevistas.
 
 \begin{quote}
 
   \noindent
-  Hi NAME,
+    Hola NOMBRE
+ 
+ Espero que no te moleste que escriba repentinamente,
+ pero quería continuar con nuestra conversación en LUGAR DE REUNIÓN
+ para ver si estarían interesados en que nosotros/as hiciéramos un taller para entrenamiento de docentes-- estamos programando  la próxima tanda durante las próximas dos semanas.
 
-  I hope you don't mind mail out of the blue,
-  but I wanted to follow up on our conversation at VENUE
-  to see if you would be interested in having us run a teacher training workshop---we're
-  scheduling the next batch over the next couple of weeks.
-
-  This one-day workshop will teach your volunteers
-  a handful of practical, evidence-based teaching practices.
-  It has been run over a hundred times in various forms on six continents
-  for nonprofit organizations, libraries, and companies,
-  and all of the material is freely available online at http://teachtogether.tech.
-  Topics will include:
+ Este taller de un día le enseñará a tus voluntarios
+ una serie de prácticas útiles de enseñanza basadas en evidencia.
+ Se ha impartido más de cien veces de diversas maneras en seis continentes
+ para organizaciones sin fines de lucro, bibliotecas y empresas,
+ y  todo el material disponible gratuitamente en línea en http://teachtogether.tech.
+ 
+El temario incluye:
 
   \begin{itemize}
-  \item learner personas
-  \item differences between different kinds of learners
-  \item using formative assessment to diagnose misunderstandings
-  \item teaching as a performance art
-  \item what motivates and demotivates adult learners
-  \item the importance of inclusivity and how to be a good ally
+  \item estudiantes tipo
+  \item  diferencias entre diferentes tipos de estudiantes 
+  \item uso de evaluaciones formativas para diagnosticar malentendidos
+  \item teaching as a performance art enseñanza como un arte performativa
+  \item que motiva y desmotiva a estudiantes adultos
+  \item la importancia de la inclusividad y como ser un buen aliado
   \end{itemize}
   
-  If this sounds interesting,
-  please give me a shout---I'd welcome a chance to talk ways and means.
-
-  Thanks,
-
-  NAME
+ Si esto te resulta interesante,
+por favor avísame-- Sería muy bienvenida la oportunidad de hablar de modos y medios para hacerlo.
+Gracias,
+  NOMBRE
 
 \end{quote}
 
-\begin{aside}{Referrals}
-  Building alliances with other groups that are doing things related to your work
-  pays off in many ways.
-  One of those is referrals:
-  if someone who approaches you for help would be better served by some other organization,
-  take a moment to make an introduction.
-  If you've done this several times,
-  add something to your website to help the next person find what they need.
-  The organizations you are helping will soon start to help you in return.
+\begin{aside}{Referencias}
+Construir alianzas con otros grupos que hacen cosas relacionadas a tu trabajo
+vale la pena de muchas maneras.
+Una de ellas son las referencias:
+si alguien se te aproxima en busca de ayuda sería mejor atendido por alguna otra organización,
+tomate un momento para hacer una introducción
+Si ya has hecho esto varias veces
+agrega algo a tu sitio web que pueda ayudar a la próxima persona a encontrar lo que necesita.
+Las organizaciones a las que estás ayudando pronto empezaran a ayudarte a cambio.
 \end{aside}
 
-\seclbl{Academic Change}{s:outreach-schools}
+Todo el mundo tiene miedo a lo desconocido y a pasar vergüenza frente a otros/as
+En consecuencia,
+la mayoría de la gente prefiere fracasar que cambiar.
+Por ejemplo,
+Lauren Herckis investigó \index{Herckis, Lauren}
+\hreffoot{https://www.insidehighered.com/news/2017/07/06/anthropologist-studies-why-professors-dont-adopt-innovative-teaching-methods}{ por que el profesorado universitario no adopta mejores metodos de enseñanza}.
+Ella halló que la razón principal es el miedo a parecer estúpido/a frente a los estudiantes;
+las razones secundarias fueron
+preocupación porque los inevitables contrastes que haya en el cambio de los métodos de enseñanza puedan afectar las evaluaciones del curso
+(que en consecuencia afectan las promoción o los cargos estables/titulares)
+y el deseo de la gente de seguir imitando a los profesores/maestros que los han inspirado.
 
-Everyone is afraid of the unknown and of embarrassing themselves.
-As a result,
-most people would rather fail than change.
-For example,
-Lauren Herckis looked at\index{Herckis, Lauren}
-\hreffoot{https://www.insidehighered.com/news/2017/07/06/anthropologist-studies-why-professors-dont-adopt-innovative-teaching-methods}{why university faculty don't adopt better teaching methods}.
-She found that the main reason is a fear of looking stupid in front of learners;
-secondary reasons were
-concern that the inevitable bumps in changing teaching methods would affect course evaluations
-(which could in turn affect promotion and tenure)
-and people's desire to continue emulating the teachers who had inspired them.
-It's pointless to argue about whether these issues are ``real'' or not:
-faculty believe they are,
-so any plan to work with faculty needs to address them\footnote{
-  And the prevalence of fixed mindset among faculty when it comes to teaching,
-  i.e.\ the belief that some people are ``just better teachers.''
-}.
+No tiene sentido discutir si estos problemas son “reales” o no:
+el profesorado cree que son reales,
+así que cualquier plan para trabajar con el profesorado necesita referirse a ellos\footnote{
+Y la prevalencia de mentalidades fijas en el profesorados a lo que se refiere a la enseñanza, es decir la creencia de que algunas personas son “solo mejores profesores” }.
 
-\cite{Bark2015} did a two-part study of how computer science educators adopt new teaching practices
-as individuals, organizationally, and in society as a whole.
-They asked and answered three key questions:
+Ellos/as preguntaron y respondieron tres preguntas claves:
 
 \begin{description}
 
-\item[How do faculty hear about new teaching practices?]
-  They intentionally seek out new practices
-  because they're motivated to solve a problem (particularly student engagement),
-  are made aware through deliberate initiatives by their institutions,
-  pick them up from colleagues,
-  or get them from expected \emph{and unexpected} interactions at conferences
-  (teaching-related or otherwise).
+\item[¿Como el profesorado se entera sobre nuevas prácticas de enseñanza?]
 
-\item[Why do they try them out?]
-  Sometimes because of institutional incentives
-  (e.g.\ they innovate to improve their chances of promotion),
-  but there is often tension at research institutions
-  where rhetoric about the importance of teaching is largely disbelieved.
-  Another important reason is their own cost/benefit analysis:
-  will the innovation save them time?
-  A third is that they are inspired by role models---again,
-  this largely affects innovations aimed to improve engagement and motivation
-  rather than learning outcomes---and a fourth is trusted sources,
-  e.g.\ people they meet at conferences who are in the same situation they are
-  and reported successful adoption.
+Buscan intencionalmente nuevas prácticas
+porque están motivados a resolver un problema ( en particular, la participación de los estudiantes),
+se tornan conscientes a través de iniciativas deliberadas por parte de sus instituciones,
+las copian o replican de sus colegas,
+o las obtienen por interacciones esperadas  \emph{e inesperadas} en conferencias
+(relacionadas a la enseñanza o de otro tipo).
 
-  But faculty had concerns that were often not addressed by people advocating changes.
-  The first was Glass's Law:
-  any new tool or practice initially slows you down,
-  so while new practices might make teaching more effective in the long run,
-  they can't be afforded in the short run.
-  Another is that the physical layout of classrooms makes many new practices hard:
-  for example,
-  discussion groups don't work well in theater-style seating.
+\item[¿Por qué las prueban?]
 
-  But the most telling result was this:
-  ``Despite being researchers themselves,
-  the CS faculty we spoke to for the most part did not believe that
-  results from educational studies were credible reasons to try out teaching practices.''
-  This is consistent with other findings:
-  even people whose entire careers are devoted to research often disregard educational research.
+Algunas veces por incentivos institucionales
+( por ejemplo innovan para mejorar sus chances de promoción),
+pero hay a veces tensión en instituciones de investigación
+donde la retórica sobre la importancia de la enseñanza tiene poca credibilidad
+Otra razón importante es su propio análisis costo/beneficio:
+¿La innovación es la que les va a ahorrar tiempo?
+Una tercera razón es que se inspiran en modelos a seguir-- otra vez,
+esto afecta en gran medida las innovaciones que tienen como objetivo mejorar la motivación y participación más que los resultados en el aprendizaje
+-- y un cuarto factor son fuentes confiables o de confianza,
+por ejemplo personas que han  conocido en congresos o conferencias que se encuentran en la misma situación que ellos/as 
+y reportaron aprobación exitosa.
+Pero el profesorado tiene preocupaciones que no siempre son abordadas por el grupo de personas que abogan por modificaciones.
+La primera era la ley de Glass:
+cualquier nueva herramienta o práctica inicialmente te ralentiza o  te vuelve más lento,
+entonces mientras que las nuevas prácticas pueden hacer la enseñanza más efectivo en el largo plazo, son costosas en el corto plazo.
+Otro es que la distribución física de las aulas torna difíciles a muchas nuevas prácticas:
+por ejemplo,
+los grupos de discusión no funcionan bien en modo de asientos estilo teatro.
 
-\item[Why do they keep using them?]
-  As~\cite{Bark2015} says, ``Student feedback is critical,''
-  and is often the strongest reason to continue using a practice,
-  even though we know that learners' self-reports don't correlate strongly with learning outcomes~\cite{Star2014,Uttl2017}
-  (though attendance in lectures is a good indicator of engagement).
-  Another reason to retain a practice is institutional requirements,
-  although if this is the only motivation,
-  people will often drop the practice
-  when the explicit incentive or monitoring is removed.
+Pero el resultado más revelador fue éste:
+`` A pesar de que ellos mismo son investigadores,
+el profesorado en ciencias de la computación con el que hablamos en su mayoría no creía
+que resultados sobre estudios educacionales fueran razones creíbles suficiente para probar prácticas de enseñanza.”
+Esto es consistente con otros hallazgos:
+incluso personas cuyas carreras están dedicadas  a la investigación a menudo ignoran investigaciones en educación. 
+
+
+\item[¿Por qué las siguen usando?]
+  Como~\cite{Bark2015} dice, ``Las devoluciones de los estudiantes son vitales,''
+y son normalmente las razones más fuertes para continuar usando una práctica,
+(aunque la asistencia a clases es un buen indicador de participación).
+aunque sabemos que las auto-evaluaciones no correlacionan fuertemente con los resultados del aprendizaje~\cite{Star2014,Uttl2017}
+Otro motivo para retener alguna  práctica es requerimiento institucional,
+aunque si esta es la única motivación,
+las personas abandonaran la práctica 
+cuando el incentivo explícito o el  monitoreo desaparecen.
+
 
 \end{description}
 
-The good news is that you can tackle these problems systematically.
-\cite{Baue2015} looked at adoption of new medical techniques within the US Veterans Administration.
+La buena noticia es que puedes abordar estos problemas sistemáticamente.
+\cite{Baue2015} observó  la adopción de nuevas tecnicas medicas dentro de la Administración de Veteranos de Estados Unidos.
+ Hallaron que prácticas basadas en evidencia en medicina
 They found that evidence-based practices in medicine
-take an average of 17 years to be incorporated into routine general practice,
-and that only about half of such practices are ever widely adopted.
-This depressing finding and others like it spurred the growth of
+toman en promedio 17 años en ser incorporadas en prácticas generales de rutina,
+y que solo la mitad de estas prácticas llegan a ser ampliamente adoptadas.
+Este deprimente hallazgo y otros han estimulado el crecimiento de
 \gref{g:implementation-science}{implementation science},
-which is the study of how to get people to adopt better practices.
+que es el estudio de cómo lograr que la gente adopte mejores prácticas.
 
-As \chapref{s:community} said,
-the starting point is to find out what the people you're trying to help believe they need.
-For example,
-\cite{Yada2016} summarizes feedback from K-12 teachers on the preparation and support they want.
-While it may not all be applicable to all settings,
-having a cup of tea with a few people and listening before you speak
-makes a world of difference to their willingness to try something new.
+Como el \chapref{s:community} decía,
+el punto de partida es hallar qué es lo que creen que necesitan las personas que quieres ayudar.
+Por ejemplo,
+\cite{Yada2016} resumen los comentarios de los maestros de  escolarizaciones primaria y secundaria en la preparación y apoyo que quieren.
+Aunque puede no ser aplicable a todos los entornos,
+tomar una taza de té con unas pocas personas y escucharlas antes de hablar
+hace un mundo de diferencia en su voluntad de intentar algo nuevo. 
 
-Once you know what people need,
-the next step is to make changes incrementally,
-within institutions' own frameworks.
-\cite{Nara2018} describes an intensive three-year bachelor's program
-based on tight-knit cohorts and administrative support
-that tripled graduation rates,
-while~\cite{Hu2017} describes the impact of introducing a six-month certification program
-for existing high school teachers who want to teach computing.
-The number of computing teachers had been stable from 2007 to 2013,
-but quadrupled after introduction of the new certification program
-without diluting quality:
-new-to-computing teachers seemed to be as effective as teachers with more computing training
-at teaching the introductory course.
+Una vez que sabes que es lo que la gente necesita,
+el siguiente paso es hacer cambios de manera incremental,
+dentro de los propios esquemas o entornos de las instituciones.
+\cite{Nara2018} describe un programa intensivo de tres años de bachillerato/licenciatura
+basado en cohortes muy unidas y apoyo administrativo
+que triplicó las tasas de graduación,
+mientras que~\cite{Hu2017} describe el impacto de implementar un programa de certificaciones de seis meses
+para profesores de secundaria que quieran enseñar computación.
+El  número de maestros de computación se ha mantenido estable entre 2007 to 2013,
+pero se cuadruplicó después de la introducción de un nuevo programa de certificación 
+sin disminuir la calidad:
+los maestros que eran novatos en impartir computación parecían ser tan efectivos en el curso introductorio como maestros con más entrenamiento en computación. 
 
-More broadly,
-\cite{Borr2014} categorizes ways to make change happen in higher education.
-The categories are defined by whether the change is individual or systemic
-and whether it is prescribed (top-down) or emergent (bottom-up).
-The person trying to make the changes (and make them stick)
-has a different role in each situation,
-and should pursue different strategies accordingly.
-The paper goes on to explain each of the methods in detail,
-while~\cite{Hend2015a,Hend2015b} present the same ideas in more actionable form.
 
-Coming from outside,
-you will probably fall into the Individual/Emergent category to start with,
-since you will be approaching teachers one by one
-and trying to make change happen bottom-up.
-If this is the case,
-the strategies Borrego and Henderson recommend center around
-having teachers reflect on their teaching individually or in groups.
-Live coding to show them what you do or the examples you use,
-then having them live code in turn
-to show how they would use those ideas and techniques in their setting,
-gives everyone a chance to pick up things that will be useful to them in their context.
+De modo más amplio,
+\cite{Borr2014} categoriza maneras para lograr que ocurran cambios en educación superior.
+Las categorías están definidas por si el cambio es individual o sistémico y si está prescripto (de arriba hacia abajo) o emergente(de abajo hacia arriba)
+La persona que trata de hacer los cambios ( y hacer que duren)
+tiene un rol distinto en cada situación,
+y de manera acorde debe seguir diferentes estrategias.
+El artículo continúa explicando en detalle cada uno de los métodos,
+mientras que~\cite{Hend2015a,Hend2015b} presenta las mismas ideas en una forma más 
+procesable.
 
-\seclbl{Free-Range Teaching}{s:outreach-free-range}
 
-Schools and universities aren't the only places people go to learn programming;
-over the past few years, a growing number have turned to free-range workshops
-and intensive bootcamp programs.
-The latter are typically one to six months long,
-run by volunteer groups or by for-profit companies,
-and target people who are retraining to get into tech.
-Some are very high quality,
-but others exist primarily to separate people from their money~\cite{McMi2017}.
+Desde el exterior o viniendo desde afuera,
+probablemente en principio caigas en alguna de las categorías  Individuo/Emergente,
+dado que te aproximarás a los maestros uno a uno
+y tratar de lograr que los cambios ocurran de abajo hacia arriba.
+Si este es el caso,
+las estrategias Borrego y Henderson recomiendan centrar alrededor
+de tener maestros que reflexionan en su enseñanza de manera individual o en grupos.
+Hacer live coding para mostrarles lo que haces o los ejemplos que usas,
+y deja que tengan su turno para hacer programación en vivo
+para mostrar cómo usarían esas ideas y técnicas en su escenario,
+les da a todos/as la oportunidad de  captar cosas que les seran útiles en su contexto.
 
-\cite{Thay2017} interviewed 26 alumni of such bootcamps
-that provide a second chance for those who missed computing education opportunities earlier
-(though phrasing it this way makes some pretty big assumptions
-when it comes to people from underrepresented groups).
-Bootcamp participants face great personal costs and risks:
-they must spend significant time, money, and effort before, during, and after bootcamps,
-and changing careers can take a year or more.
-Several interviewees felt that their certificates were looked down on by employers;
-as some said,
-getting a job means passing an interview,
-but since interviewers often won't share their reasons for rejection,
-it's hard to know what to fix or what else to learn.
-Many resorted to internships (paid or otherwise)
-and spent a lot of time building their portfolios and networking.
-The three informal barriers they most clearly identified were jargon,
-impostor syndrome,
-and a sense of not fitting in.
 
-\cite{Burk2018} dug into this a bit deeper
-by comparing the skills and credentials that tech industry recruiters are looking for
-to those provided by four-year degrees and bootcamps.
-Based on interviews with 15 hiring managers from firms of various sizes and some focus groups,
-they found that recruiters uniformly emphasized soft skills
-(especially teamwork, communication, and the ability to continue learning).
-Many companies required a four-year degree
-(though not necessarily in computer science),
-but many also praised bootcamp graduates for being older or more mature
-and having more up-to-date knowledge.
+\seclbl{Docentes de rango libre}{s:outreach-free-range}
 
-If you are approaching an existing bootcamp,
-your best strategy could be to emphasize what you know about teaching
-rather than what you know about tech,
-since many of their founders and staff have programming backgrounds
-but little or no training in education.
-The first few chapters of this book have played well with this audience in the past,
-and~\cite{Lang2016} describes
-evidence-based teaching practices that can be put in place
-with minimal effort and at low cost.
-These may not have the most impact,
-but scoring a few early wins helps build support for larger efforts.
+Las escuelas y las universidades no son los únicos lugares en donde la gente las personas pueden ir a aprender programación;
+en los últimos años, un número creciente a turned a talleres de rango libre y programas intensivos.
+Estos últimos típicamente duran uno a seis meses,
+run by grupos de voluntarios o por empresas con fines de lucro,
+y su objetivo son personas que se están re-entrenando para entrar en tecnología.
+Algunos son de muy alta calidad,
+pero otros existen primariamente para separar personas de su dinero~\cite{McMi2017}.
 
-\seclbl{Final Thoughts}{s:outreach-final}
 
-It is impossible to change large institutions on your own:
-you need allies,
-and to get allies,
-you need tactics.
-The most useful guide I have found is~\cite{Mann2015},
-which catalogs more than four dozen of these
-and organizes them according to whether they're best deployed early,
-later,
-throughout the change cycle,
-or when you encounter resistance.
-A handful of their patterns include:
+\cite{Thay2017} entrevistó a 26 graduados de estos entrenamientos intensivos
+que proveen de una segunda oportunidad para aquellos que no tuvieron antes oportunidades de educación en computación
+( aunque expresarlo de este modo realizar ciertas grandes suposiciones 
+cuando se refiere a personas de grupos poco representados).
+Los participantes de los entrenamientos intensivos enfrentan grandes costos y riesgos personales:
+deben pasar una cantidad significativa de tiempo, dinero y esfuerzo antes durante y después de los entrenamientos intensivos, y cambiar de carreras puede tomar un año o más.
+Varios de los entrevistados sienten que sus certificados fueron mal vistos por sus empleadores;
+como dicen algunos,
+obtener un trabajo significa aprobar una entrevista,
+pero dado que los entrevistadores muchas veces no comparten sus motivos para rechazar,
+es difícil saber que arreglar o que más aprender.
+Muchos/as han tenido que recurrir a pasantías (pagas o de otro tipo)
+y pasan mucho tiempo construyendo sus portfolios y haciendo networking.
+Las tres barreras informales que más fácilmente identificables son jerga,
+síndrome del impostor, y una sensación de no encajar.
+
+
+\cite{Burk2018} profundizó en esto
+comparando las habilidades y credenciales que los reclutadores de la industria tecnológica buscan 
+entre  entrenamientos intensivos y grados/diplomas/carreras de cuatro años.
+Basándose en entrevistas con 15 gerentes de contratación de empresas de varios tamaños y algunos grupos focales,
+encontraron que los reclutadores enfatizaban uniformemente en habilidades “blandas”
+(especialmente trabajo en equipo, comunicación y la habilidad para continuar aprendiendo)
+Muchas compañías requieren un título de cuatro años
+(aunque no necesariamente en informática),
+pero muchos también elogiaron a los graduados de  entrenamientos intensivos por ser mayores en edad o más maduros
+y tener un conocimiento más actualizado.
+
+
+Si te está aproximas a un  entrenamiento intensivo existente,
+tu mejor estrategia podría ser enfatizar lo que sabes sobre enseñanza
+en lugar de lo que sabes sobre tecnología,
+dado que muchos de sus fundadores y personal tienen experiencia en programación
+pero poca o ninguna capacitación en educación.
+Los primeros capítulos de este libro en el pasado han servido bien con esta audiencia,
+y ~\cite{Lang2016} describe
+prácticas de enseñanza basadas en evidencia que pueden implementarse
+con mínimo esfuerzo y a bajo costo.
+éstas tal vez no tengan el mayor impacto, 
+pero lograr algunas victorias tempranas ayuda a generar apoyo para esfuerzos más grandes.
+
+
+
+\seclbl{Reflexiones Finales }{s:outreach-final}
+Es imposible cambiar grandes instituciones por tu propia cuenta:
+necesitas aliados
+y para conseguir aliados,
+necesitas tácticas.
+La guía más útil que he encontrado es~\cite{Mann2015}, 
+que cataloga más de cuatro docenas de estas tácticas
+y las organiza de acuerdo a si se implementan mejor temprano,
+luego,
+a lo largo del ciclo de cambio,
+o cuando encuentras resistencia.
+Algunos de sus patrones incluyen:
 
 \begin{description}
 
-\item[In Your Space:]
-  Keep the new idea visible
-  by placing reminders throughout the organization.
+\item[En tu espacio:]
+Mantén la nueva idea visible
+ubicando recordatorios a lo largo de la organización.
 
-\item[Token:]
-  To keep a new idea alive in a person's memory,
-  hand out tokens that can be identified with the topic being introduced.
+\item[Símbolo o recuerdo:] 
+Para mantener viva una nueva idea en la memoria de una persona,
+entregue un recuerdo (COMENTARIO esto es token, no es un souvenir)   que puedan identificarse con el tema que se está introduciendo.
 
-\item[Champion Skeptic:]
-  Ask strong opinion leaders who are skeptical of your new idea
-  to play the role of ``official skeptic.''
-  Use their comments to improve your effort,
-  even if you don't change their minds.
+\item[Campeón escéptico:]
+Pregunte a los líderes con opiniones  fuertes que sean escépticos de la nueva idea.
+para desempeñar el papel/rol de ``escéptico oficial ''.
+Usa sus comentarios para mejorar tu esfuerzo,
+incluso si no logras cambiar su opinión.
 
-\item[Future Commitment:]
-  If you are able to anticipate some of your needs,
-  you can ask for a future commitment from busy people.
-  If given some lead time,
-  they may be more willing to help.
+
+\item[Compromiso Futuro:]
+ 
+ Si puedes anticipar algunas de sus necesidades,
+puedes pedir un compromiso futuro a las personas más ocupadas.
+Si se les da un tiempo de entrega,
+pueden estar más dispuestos a ayudar.
+
   
 \end{description}
 
-The most important strategy is
-to be willing to change your goals
-based on what you learn from the people you are trying to help.
-Tutorials showing them how to use a spreadsheet
-might help them more quickly and more reliably than
-an introduction to JavaScript.
-I have often made the mistake of confusing things I was passionate about
-with things that other people ought to know;
-if you truly want to be a partner,
-always remember that learning and change have to go both ways.
+La estrategia más importante es
+estar dispuesto a cambiar tus metas
+según lo que aprendas de las personas a las que intentas ayudar.
+Tutoriales que les muestran cómo usar una hoja de cálculo
+podría ayudarlos de manera más rápida y confiable que
+una introducción a JavaScript.
+A menudo he cometido el error de confundir cosas que me apasionaban
+con cosas que las otras personas deberían saber;
+si realmente quieres ser quien acompañe,
+recuerda siempre que el aprendizaje y el cambio tienen que ir en ambos sentidos.
 
-The hardest part about building relationships is getting started.
-Set aside an hour or two every month
-to find allies and maintain your relationships with them.
-One way to do this is to ask them for advice:
-how do they think you ought to raise awareness of what you're doing?
-Where have they found space to run classes?
-What needs do they think aren't being met
-and would you be able to meet them?
-Any group that has been around for a few years will have useful advice;
-they will also be flattered to be asked,
-and will know who you are the next time you call.
+La parte más difícil de construir relaciones es comenzarlas.
+Reserva una o dos horas cada mes
+para encontrar aliados y mantener tus relaciones con ellos.
+Una forma de hacer esto es pedirles consejo:
+¿Cómo creen que deberías crear conciencia de lo que están haciendo?
+¿Dónde han encontrado espacio para dar clases?
+¿Qué necesidades creen que no se están cumpliendo
+y serías capaz de cumplir?
+Cualquier grupo que haya existido durante algunos años tendrá consejos útiles;
+también se sentirán halagados de que se les haya consultado,
+y sabrán quién eres la próxima vez que llames.
 
-And as~\cite{Kuch2011} says,
-if you can't be first in a category,
-try to create a new category that you can be first in.
-If you can't do that,
-join an existing group or think about doing something else entirely.
-This isn't defeatist:
-if someone else is already doing what you have in mind,
-you should either chip in or tackle one of the other equally useful things
-you could be doing instead.
 
-\seclbl{Exercises}{s:outreach-exercises}
+Y como~\cite{Kuch2011} decía,
+si no puedes ser el primero/a en una categoría,
+intenta crear una nueva categoría en la que sí  puedas ser el primero/a.
+Si no puedes hacer eso,
+únete a un grupo existente o piensa en hacer algo completamente diferente.
+Esto no es derrotista:
+si alguien más ya está haciendo lo que tienes en mente,
+deberías incorporarte o abordar una de las otras cosas igualmente útiles
+que podrías estar haciendo en su lugar.
 
-\exercise{Pitching a City Councilor}{individual}{10}
+\seclbl{Ejercicios}{s:outreach-exercises}
 
-This chapter described an organization
-that offers weekend programming workshops for people re-entering the workforce.
-Write an elevator pitch for that organization
-aimed at a city councilor whose support the organization needs.
+\exercise{Discurso de presentación para un/a concejal}{individual}{10}
 
-\exercise{Pitching Your Organization}{individual}{30}
+Este capítulo describe una organización
+que ofrece talleres de programación de fin de semana para personas que re-ingresan a la fuerza laboral.
+Escribir un discurso de presentación para esa organización
+dirigido a un concejal de la ciudad cuyo apoyo las organización necesita.
 
-Identify two groups of people your organization needs support from
-and write an elevator pitch aimed at each one.
 
-\exercise{Email Subjects}{pairs}{10}
+\exercise{Presenta tu Organización}{individual}{30}
 
-Write the subject lines (and only the subject lines) for three email messages:
-one announcing a new course,
-one announcing a new sponsor,
-and one announcing a change in project leadership.
-Compare your subject lines to a partner's
-and see if you can merge the best features of each while also shortening them.
+Identifica dos grupos de personas de la que tu organización necesite apoyo
+y escribe un discurso de presentación dirigido a cada uno/a.
 
-\exercise{Handling Passive Resistance}{small groups}{30}
 
-People who don't want change will sometimes say so out loud,
-but may also often use various forms of passive resistance,
-such as just not getting around to it over and over again,
-or raising one possible problem after another
-to make the change seem riskier and more expensive than it's actually likely to be
-\cite{Scot1987}.
-Working in small groups,
-list three or four reasons why people might not want your teaching initiative to go ahead,
-and explain what you can do with the time and resources you have to counteract each.
+\exercise{Adjuntos de correo electrónico}{pares/parejas}{10}
 
-\exercise{Why Learn to Program?}{individual}{15}
+Escriban las líneas de asunto (y solo las líneas de asunto) para tres mensajes de correo electrónico:
+uno anunciando un nuevo curso,
+uno anunciando un nuevo patrocinador,
+y uno que anuncia un cambio en el liderazgo del proyecto.
+Compare sus líneas de asunto con las de un compañero/a
+y vea si pueden combinar las mejores características de cada una mientras que también las acortan.
 
-Revisit the ``Why Learn to Program?'' exercise in \secref{s:intro-exercises}.
-Where do your reasons for teaching and your learners' reasons for learning align?
-Where do they not?
-How does that affect your marketing?
+\exercise{Manejando la Resistencia Pasiva}{grupos pequeños}{30}
 
-\exercise{Conversational Programmers}{think-pair-share}{15}
+Las personas que no quieren cambios a veces lo dicen en voz alta:
+pero a menudo también pueden usar varias formas de resistencia pasiva,
+como simplemente no lidiar con ello una y otra vez,
+o planteando un posible problema tras otro 
+para hacer que el cambio parezca más arriesgado y más costoso de lo que probablemente es
+\ cite {Scot1987}.
+Trabajando en grupos pequeños,
+enumere tres o cuatro razones por las cuales las personas podrían no querer que su iniciativa de enseñanza siga adelante,
+y explique qué puede hacer con el tiempo y los recursos que tiene para contrarrestar cada una de esas razones.
 
-A \gref{g:conversational-programmer}{conversational programmer}
-is someone who needs to know enough about computing
-to have a meaningful conversation with a programmer,
-but isn't going to program themselves.
-\cite{Wang2018} found that most learning resources don't address this group's needs.
-Working in pairs,
-write a pitch for a half-day workshop intended to help people that fit this description
-and then share your pair's pitch with the rest of the class.
 
-\exercise{Collaborations}{small groups}{30}
+\exercise{Por que/para que aprender a programar?}{individual}{15}
 
-Answer the following questions on your own,
-then compare your answers to those given by other members of your group.
+Revise el ejercicio ``¿Por qué aprender a programar?'' En \ secref {s: intro-exercise}.
+¿Dónde se alinean sus razones para enseñar y las razones de sus alumnos para aprender?
+¿y donde no?
+¿Cómo afecta eso a su comercialización?
+
+\exercise{Conversational Programmers}{pensar en parejas y compartir}{15}
+
+Un/a \gref{g:conversational-programmer}{programador/a conversacional}
+es alguien que necesita saber lo suficiente sobre informática
+para tener una conversación valiosa con un programador,
+pero ellos mismos no van a programar.
+
+\cite{Wang2018} descubrió que la mayoría de los recursos de aprendizaje no abordan las necesidades de este grupo.
+Trabajando en parejas/pares,
+escriban un discurso para un taller de medio día destinado a ayudar a las personas que se ajustan a esta descripción
+y luego comparte el discurso de tu pareja con el resto de la clase.
+
+
+\exercise{Colaboraciones}{grupos pequeños}{30}
+Responda por su cuenta las siguientes preguntas,
+luego compare sus respuestas con las dadas por otros miembros de su grupo.
+
 
 \begin{enumerate}
 
 \item
-  Do you have any agreements or relationships with other groups?
+¿Tiene algún acuerdo o relación con otros grupos?
 
 \item
-  Do you want to have relationships with any other groups?
-
+¿Quieres tener relaciones con algún otro grupo?
 \item
-  How would having (or not having) collaborations
-  help you to achieve your goals?
-
+¿Cómo tener (o no tener) colaboraciones
+podría ayudar a alcanzar sus objetivos?
 \item
-  What are your key collaborative relationships?
-
+¿Cuáles son sus relaciones colaborativas clave?
 \item
-  Are these the right collaborators for achieving your goals?
-
+¿Son estos los colaboradores adecuados o indicados para alcanzar sus objetivos?
 \item
-  What groups or entities would you like your organization
-  to have agreements or relationships with?
+¿Qué grupos o entidades quisieras que tu organización
+tenga acuerdos o lazos ?
+
 
 \end{enumerate}
 
-\exercise{Educationalization}{whole class}{10}
+\exercise{Educacionalización}{toda la clase}{10}
 
-\cite{Laba2008} explores why the United States and other countries
-keep pushing the solution of social problems onto educational institutions
-and why that continues not to work.
-As he points out,
-``[Education] has done very little to promote equality of race, class, and gender;
-to enhance public health, economic productivity, and good citizenship;
-or to reduce teenage sex, traffic deaths, obesity, and environmental destruction.
-In fact,
-in many ways it has had a negative effect on these problems
-by draining money and energy away from social reforms that might have had a more substantial impact.''
-He goes on to write:
+\cite{Laba2008} explora porque en los Estados Unidos y en otros países
+siguen empujando la solución de problemas sociales hacia las instituciones educativas 
+y eso sigue sin funcionar.
+él remarca,
+``[Educación] ha hecho muy poco para promover igualdad de raza, clase, y género;
+para mejorar la salud pública, la productividad económica y buena ciudadanía;
+o reducir el sexo en adolescente, las muestras por accidentes de tránsito, obesidad y la destrucción ambiental.
+De hecho,
+de muchas maneras ha tenido un efecto negativo en estos problemas
+sacando dinero y energía de las reformas sociales que podrían tener un impacto más substancial.”
+Él continúa escribiendo: 
+
 
 \begin{quote}
 
-  So how are we to understand the success of this institution
-  in light of its failure to do what we asked of it?
-  One way of thinking about this is that
-  education may not be doing what we ask,
-  but it is doing what we want.
-  We want an institution that will pursue our social goals
-  in a way that is in line with the individualism at the heart of the liberal ideal,
-  aiming to solve social problems
-  by seeking to change the hearts, minds, and capacities of individual students.
-  Another way of putting this is that
-  we want an institution through which we can express our social goals
-  without violating the principle of individual choice
-  that lies at the center of the social structure,
-  even if this comes at the cost of failing to achieve these goals.
-  So education can serve as a point of civic pride,
-  a showplace for our ideals,
-  and a medium for engaging in uplifting but ultimately inconsequential disputes
-  about alternative visions of the good life.
-  At the same time,
-  it can also serve as a convenient whipping boy
-  that we can blame for its failure to achieve our highest aspirations for ourselves as a society.
+  Entonces, ¿cómo debemos entender el éxito de esta institución?
+a la luz de su no hacer lo que le pedimos?
+Una forma de pensar en esto es que
+la educación puede no estar haciendo lo que pedimos,
+pero está haciendo lo que queremos.
+Queremos una institución que persiga nuestros objetivos sociales.
+de una manera que está en línea con el individualismo en el corazón del ideal liberal,
+con el objetivo de resolver problemas sociales
+buscando cambiar los corazones, las mentes y las capacidades de cada estudiante.
+Otra forma de decir esto es que
+queremos una institución a través de la cual podamos expresar nuestros objetivos sociales
+sin violar el principio de elección individual
+que se encuentra en el centro de la estructura social,
+incluso si esto tiene el costo de no lograr estos objetivos.
+Entonces la educación puede servir como un punto de orgullo cívico,
+un lugar de muestra para nuestros ideales,
+y un medio para participar en disputas edificantes pero  que en última instancia son intrascendentes
+sobre visiones alternativas de la buena vida.
+Al mismo tiempo,
+también puede servir como un conveniente chivo expiatorio
+al que podemos culpar por su fracaso en lograr nuestras más altas aspiraciones para nosotros mismos como sociedad.
+
 
 \end{quote}
 
-How do efforts to teach computational thinking and digital citizenship in schools
-fit into this framework?
-Do bootcamps avoid these traps or simply deliver them in a new guise?
+¿Cómo encajar en este marco los esfuerzos que se hacen para enseñar pensamiento computacional y ciudadanía digital en las escuelas?
+¿Los entrenamientos intensivos evitan estas trampas o simplemente las entregan con una nueva apariencia?
 
-\exercise{Institutional Adoption}{whole class}{15}
+\exercise{Adopción Institucional}{ clase completa}{15}
 
-Re-read the list of motivations to adopt new practices
-given in \secref{s:outreach-schools}.
-Which of these apply to you and your colleagues?
-Which are irrelevant to your context?
-Which do you emphasize
-if and when you interact with people working in formal educational institutions?
+Re-leer la lista de motivaciones para adoptar nuevas prácticas
+dadas en \secref{s:outreach-schools}.
+¿Cuáles de estos se aplican a tí y tus colegas?
+¿Cuáles son irrelevantes en tu contexto?
+¿Cual enfatizamos
+cuando y si interactúas con personas que trabajan en instituciones educativas formales?
 
-\exercise{If At First You Don't Succeed}{small groups}{15}
 
-W.C.~Fields probably never said,
-``If at first you don’t succeed, try, try again.
-Then quit---there's no use being a damn fool about it.''
-It's still good advice:
-if the people you're trying to reach aren't responding,
-it could be that you'll never convince them.
-In groups of 3--4,
-make a short list of signs that you should stop trying to do something you believe in.
-How many of them are already true?
+\exercise{Si al principio no tienes éxito}{grupos pequeños}{15}
 
-\exercise{Making It Fail}{individual}{15}
+W.C.~Fields probablemente nunca dijo,
+``Si al principio no tienes éxito, inténtalo, inténtalo de nuevo.
+Entonces déjalo, no sirve de nada ser un tonto al respecto''
+Sigue siendo un buen consejo:
+si las personas con las que intenta comunicarse no responden,
+podría ser que nunca los convencerás.
+En grupos de 3 a 4,
+hagan una breve lista de señales de que se debe dejar de intentar hacer algo en lo que cree.
+¿Cuántos de ellos ya son verdaderos?
 
-\cite{Farm2006} presents some tongue-in-cheek rules for ensuring that new tools \emph{aren't} adopted,
-all of which apply to new teaching practices:
+
+\exercise{Logrando/Haciendo que falle}{individual}{15}
+\cite{Farm2006} presenta algunas reglas ironicas para lograr que nuevas herramientas \emph{no} sean adoptadas,
+todas de las cuales aplican a nuevas prácticas de enseñanza:
 
 \begin{enumerate}
 
 \item
-  Make it optional.
+  Hacerlo opcional.
 
 \item
-  Economize on training.
+Economizar en entrenamiento. 
 
 \item
-  Don't use it in a real project.
+  No usarlas en un proyecto real.
 
 \item
-  Never integrate it.
+  Nunca integrarlas.
 
 \item
-  Use it sporadically.
+Usarlas esporádicamente.
 
 \item
-  Make it part of a quality initiative.
+  Hacerlas parte de una iniciativa de calidad
 
 \item
-  Marginalize the champion.
+  Marginalizar al campeón.
 
 \item
-  Capitalize on early missteps.
+Capitalizar en los primeros errores.
 
 \item
-  Make a small investment.
+Hacer una inversión pequeña
 
 \item
-  Exploit fear, uncertainty, doubt, laziness, and inertia.
+ Explotar miedo, incertidumbre, duda, pereza e inercia.
+
 
 \end{enumerate}
 
-Which of these have you seen done recently?
-Which have you done yourself?
-What form did they take?
+¿Cuál de estas has visto  hechas recientemente?
+¿Cuales has hecho tú mismo?
+¿Qué forma tuvieron?
+
 
 \exercise{Mentoring}{whole class}{15}
 
+\exercise{Mentoreo}{todo la clase/todo el grupo}{15}
+
 The \hreffoot{http://www.iaamcs.org/}{Institute for African-American Mentoring in Computer Science}
-has published \hreffoot{http://iaamcs.org/guidelines}{guidelines for mentoring doctoral students}.
-Read them individually,
-then go through them as a class
-and rate your efforts for your own group as +1 (definitely doing),
-0 (not sure or not applicable),
-or -1 (definitely not doing).
+ha publicado \hreffoot{http://iaamcs.org/guidelines}{ guías para mentorear estudiantes de doctorado}.
+Lea individualmente
+luego discutan como una clase
+y califica los esfuerzos para tu propio grupo como +1 (definitivamente haciendo),
+0 (no estoy seguro o no es aplicable),
+o -1 (definitivamente no se está haciendo).
+
+


### PR DESCRIPTION
Traducción del capitulo outreach, términos como branding, marketing quedan sin traducir, hay palabras que no se si hay un equivalente en latinoamerica (lo de school board o council) o si el sentido es el mismo (champion)