### PR TITLE
Correction of capital letters on titles

### DIFF
--- a/es/memory.tex
+++ b/es/memory.tex
@@ -1,4 +1,4 @@
-\chapter{Pericia y Memoria}\label{s:memory}
+\chapter{Pericia y memoria}\label{s:memory}
 
 \begin{quote}
 
@@ -7,7 +7,7 @@
 
 \end{quote}
 
-El capítulo anterior explicaba las diferencias entre practicantes novatos y competentes.
+El capítulo anterior explicaba las diferencias entre personas novatas y practicantes competentes.
 En  éste se observa la pericia:
 qué es,
 cómo se puede adquirir,
@@ -95,7 +95,7 @@ y lo bueno que es para enseñarlo~\cite{Mars2002}.
 
 \end{aside}
 
-\seclbl{Mapas Conceptuales}{s:memory-concept-maps}
+\seclbl{Mapas conceptuales}{s:memory-concept-maps}
 
 La herramienta que elegimos para representar el modelo mental de alguien es un \gref{g:concept-map}{mapa conceptual},
 en el cual los hechos son burbujas y las conexiones son relaciones etiquetadas.
@@ -134,7 +134,7 @@ Los mapas conceptuales pueden ser usados de varias maneras:
 
 \begin{description}
 
-\item[Ayudando a docentes para descubrir que están tratando de enseñar.]
+\item[Ayudando a docentes para descubrir qué están tratando de enseñar.]
   Un mapa conceptual separa el contenido del orden:
   en nuestra experiencia,
   las personas rara vez terminan enseñando las cosas en el orden que las dibujaron por primera vez.
@@ -192,7 +192,7 @@ p.ej.\ hacen visibles los modelos mentales de manera que pueden ser comparados y
  Lady Windermere, obra de Oscar Wilde,\index{Wilde, Oscar}
 las personas a menudo no saben lo que piensan hasta que se escuchan a sí mismas decirlo}.
 
-\begin{aside}{Trabajo crudo y Honestidad}
+\begin{aside}{Trabajo crudo y honestidad}
   Muchos diseñadores de interfaces de usuario creen que es mejor mostrar a la gente bocetos de sus ideas en lugar de maquetas pulidas
   porque estiman que  las personas dan una opinión más honesta sobre algo que 
   consideran solo ha requirido unos pocos minutos crear:
@@ -203,7 +203,7 @@ las personas a menudo no saben lo que piensan hasta que se escuchan a sí mismas
   en lugar de sofisticadas herramientas de dibujo por computadora.
 \end{aside}
 
-\seclbl{Siete Más o Menos Dos}{s:memory-seven-plus-or-minus}
+\seclbl{Siete más o menos dos}{s:memory-seven-plus-or-minus}
 
 Mientras el modelo gráfico de conocimiento es incorrecto pero útil,
 otro modelo simple tiene bases fisiológicas profundas.
@@ -257,7 +257,7 @@ luego agregará otro fragmento para la próxima lección y así sucesivamente.
 
 \figpdf{figures/photosynthesis.pdf}{Usando mapas conceptuales en el diseño de la lección}{f:memory-photosynthesis}
 
-\begin{aside}{Construyendo juntos mapas conceptuales}
+\begin{aside}{Construyendo mapas conceptuales en comunidad}
  La próxima vez que tengas una reunión de equipo,
  entrega a todos una hoja de papel
  y que pasen unos minutos dibujando sus propios mapas conceptuales del proyecto en el que  están trabajando.
@@ -273,7 +273,7 @@ en el que la memoria a corto plazo se divide en varios almacenamientos
 cada uno de los cuales realiza un preprocesamiento involuntario~\cite{Mill2016a}.
 Nuestra presentación es entonces un ejemplo de un modelo mental que ayuda al aprendizaje y al trabajo diario.
 
-\subsection*{Reconocimiento de Patrones}
+\subsection*{Reconocimiento de patrones}
 
 Investigaciones recientes sugieren que el tamaño real de la memoria a corto plazo 
 podría ser tan bajo como 4±1 elementos~\cite{Dida2016}.
@@ -303,9 +303,9 @@ dar nombres a un pequeño número de patrones parece ayudar con la enseñanza,
 principalmente dando a los alumnos un vocabulario más rico para pensar y comunicarse \cite{Kuit2004,Byck2005,Saja2006}.
 Volveremos a este tema en \secref{s:pck-programación}.
 
-\seclbl{Convirtiéndose en Experto}{s:memory-becoming-expert}
+\seclbl{Convirtiéndose en persona experta}{s:memory-becoming-expert}
 
-Entonces cómo se convierte alguien en experto?
+Entonces, ¿cómo se convierte alguien en una persona experta?
 La idea de que diez mil horas de práctica lo harán es ampliamente citada
 pero \hreffoot{http://www.goodlifeproject.com/podcast/anders-ericsson/}{probablemente no sea verdad}:
 hacer lo mismo una y otra vez es más probable que fortalezca los malos hábitos a que mejore la actuación.
@@ -335,7 +335,7 @@ y una progresión común es que las personas pasen por tres etapas:
 
 \end{description}
 
-\begin{aside}{¿Qué cuenta como Práctica Deliberada?}
+\begin{aside}{¿Qué cuenta como práctica deliberada?}
   \cite{Macn2014} descubrió que,
   ``{\ldots}la práctica deliberada explicaba el 26\% de la varianza en el rendimiento de los juegos,
   21\% para música,
@@ -361,7 +361,7 @@ Discutan con tu colega y critiquen el mapa de cada uno.
 ¿Presentan conceptos o detalles de superficie?
 ¿Cuáles de las relaciones en el mapa de tu colega consideras conceptos y viceversa?
 
-\exercise{ Mapeo de Conceptos (Nuevamente)}{grupos pequeños}{20}
+\exercise{ Mapeo de conceptos (Nuevamente)}{grupos pequeños}{20}
 
 Trabajar en grupos de 3--4,
 cada persona debe dibujar independientemente del resto un mapa conceptual mostrando su modelo mental de qué sucede en un aula.
@@ -379,13 +379,13 @@ Cuando intercambiaste mapas conceptuales en el ejercicio anterior,
 ¿Qué tan fácil fue para otras personas entender lo que significaba tu mapa?
 ¿Qué tan fácil sería para ti si lo dejas de lado por un día o dos y luego lo miras de nuevo?
 
-\exercise{Eso es un poco autorreferencial, ¿no??}{toda la clase}{30}
+\exercise{Eso es un poco autorreferencial, ¿no?}{toda la clase}{30}
 
 Trabajando independientemente,
 dibuja un mapa conceptual para mapas conceptuales.
 Compara tu mapa conceptual con los dibujados por los demás.
-Qué incluyeron la mayoría de las personas?
-Cuáles fueron las diferencias más significativas?
+¿Qué incluyeron la mayoría de las personas?
+¿Cuáles fueron las diferencias más significativas?
 
 \exercise{Notar tus puntos ciegos}{grupos pequeños}{10}
 


### PR DESCRIPTION
A quick revision on titles (we have agreeded not to capitalize all the words of the titles). 
I also edited a few terms with genre mark (experto > persona experta, and others), the chapter may need a more detailed reading on this