### PR TITLE
Add utf8 input to book.tex

### DIFF
--- a/es/book.tex
+++ b/es/book.tex
@@ -1,5 +1,6 @@
 \documentclass[]{../tex/krantz}
 \usepackage[spanish]{babel}
+\usepackage[utf8]{inputenc}
 \input{../tex/pdf-settings}
 
 \begin{document}


### PR DESCRIPTION
this solves Linux encoding issue in pdflatex
@yabellini check if it compiles fine in Windows