### PR TITLE
Revision of architecture.tex - Spanish translation

### DIFF
--- a/es/architecture.tex
+++ b/es/architecture.tex
@@ -376,7 +376,7 @@ independientemente de la experiencia previa con computadoras~\cite{Lazo1993}.
   Se enfatizaba que los/las usuarios/as generalmente aportan mucha experiencia y conocimiento a este aprendizaje,
   por ejemplo,
   conocimiento sobre el dominio de la tarea,
-  y que dicho conocimiento podría ser un recurso para los/as diseñadores de instructivos.
+  y que dicho conocimiento podría ser un recurso para los/as diseñadores/as de instructivos.
   El minimalismo aprovechó los episodios de reconocimiento, diagnóstico y corrección de errores,
   en lugar de intentar simplemente prevenirlos. Es decir,
   enmarcó la resolución de problemas y la corrección como oportunidades de aprendizaje en lugar de aberraciones.

--- a/es/architecture.tex
+++ b/es/architecture.tex
@@ -1,17 +1,17 @@
 \chapter{Arquitectura cognitiva}\label{s:architecture}
 
 Hemos hablado acerca de modelos mentales como si fueran cosas reales,
-pero ¿qué es lo que realmente sucede en el cerebro de un aprendiz cuando está aprendiendo?
+pero ¿qué es lo que realmente sucede en el cerebro de una persona cuando está aprendiendo?
 La respuesta corta es que no lo sabemos, la respuesta larga es que sabemos mucho más que antes.
-Este capítulo profundizará en lo que el cerebro hace mientras el aprendizaje sucede
-y cómo podemos aprovechar eso para diseñar y brindar lecciones de manera más efectiva.
+Este capítulo profundizará en qué hace el cerebro hace mientras el aprendizaje sucede
+y en cómo podemos aprovecharlo para diseñar y brindar lecciones de manera más efectiva.
 
 \seclbl{¿Qué es lo que sucede allí?}{s:architecture-brain}
 
-\figpdf{figures/cognitive-architecture.pdf}{Arquitectura Cognitiva}{f:arch-model}
+\figpdf{figures/cognitive-architecture.pdf}{Arquitectura cognitiva}{f:arch-model}
 
 La figura \figref{f:arch-model} es un modelo simplificado de la arquitectura cognitiva humana. \index{cognitive architecture}
-El núcleo de este modelo es la separación entre la memoria a corto y a largo plazo vistas en \secref{s:memory-seven-plus-or-minus}.
+El núcleo de este modelo es la separación entre la memoria a corto y a largo plazo vistas en la \secref{s:memory-seven-plus-or-minus}.
 La memoria a largo plazo es como tu sótano:\index{long-term memory}
 almacena objetos de forma más o menos permanente
 pero tu conciencia no puede acceder a ella directamente.
@@ -33,46 +33,46 @@ y del canal visual\index{visual channel}
 (para las imágenes)\footnote{
   Un modelo más completo
   también incluiría el sentido del tacto, del olfato y del gusto,
-  pero por ahora, los ignoraremos.}.
-La mayoría de las personas confía principalmente en su canal visual,
-pero cuando las imágenes y las palabras se complementan entre sí,
-el cerebro hace un mejor trabajo al recordarlas a ambas:
+  pero por ahora los ignoraremos.}.
+Si bien la mayoría de las personas confía principalmente en su canal visual,
+cuando las imágenes y las palabras se complementan entre sí
+el cerebro hace un mejor trabajo al recordarlas:
 se codifican juntas,
-de modo que el recuerdo de una más tarde ayude a activar el recuerdo de la otra.
+de modo que el recuerdo de una más tarde ayuda a activar el recuerdo de la otra.
 
-Las entradas lingüísticas y visuales son procesadas por diferentes partes del cerebro humano,
+Las entradas lingüísticas y visuales son procesadas por diferentes partes del cerebro humano
 y a su vez los recuerdos lingüísticos y visuales son almacenados también de manera separada.
 Esto significa que correlacionar flujos de información lingüísticos y visuales requiere esfuerzo cognitivo:
 si alguien lee algo mientras lo escucha en voz alta,
 su cerebro no puede evitar comprobar que obtiene la misma información por ambos canales.
 
 Por lo tanto, el aprendizaje aumenta cuando la información se presenta de manera simultánea por dos canales diferentes,
-pero se reduce cuando esa información es redundante, en lugar de ser complementaria,
+pero se reduce cuando esa información es redundante, en lugar de ser complementaria:
 tal fenómeno es conocido como \gref{g:split-attention-effect}{efecto de atención dividida}~\cite{Maye2003}.
 Por ejemplo, en general las personas encuentran más difícil aprender de un video que tiene narración y
-al mismo tiempo capturas de pantalla que de uno que solo tiene narración o capturas (pero no ambos elementos),
+al mismo tiempo capturas de pantalla que de uno que únicamente tiene narración o capturas (pero no ambos elementos),
 porque en el primer caso parte de su atención ha sido utilizada para chequear que la narración  
-y las capturas se correspondan entre sí. Dos notables excepciones a esto,
+y las capturas se correspondan entre sí. Dos notables excepciones 
 son las personas que aún no hablan bien un idioma y las que tienen algún impedimento auditivo u
 otras necesidades especiales, quienes quizás encuentren que el valor de la información redundante
 supera el esfuerzo de procesamiento adicional.
 
-\begin{aside}{Pieza por pieza}
-  El efecto de la atención dividida explica porque es más efectivo dibujar un diagrama
-  pieza por pieza mientras enseñas que presentar todo el gráfico de una sola vez.
+\begin{aside}{Fragmento a fragmento}
+  El efecto de la atención dividida explica por qué es más efectivo dibujar un diagrama
+  fragmento a fragmento mientras enseñas, en lugar de presentar todo el gráfico de una sola vez.
   Si las partes de un diagrama aparecen al mismo tiempo en que los gráficos son explicados,
-  ambos elementos serán correlacionados en la memoria del aprendiz.
-  Enfocarnos luego solo en una parte del diagrama es lo más parecido a activar la recuperación
+  el/la estudiante correlaciona ambos elementos en su memoria.
+  Así, al luego enfocarte en una parte del diagrama es más probable que tu estudiante active la recuperación
   de lo que fue dicho cuando esa parte fue dibujada.
 \end{aside}
 
 El efecto de la atención dividida \emph{no} significa
-que las/los estudiantes no deberían intentar conciliar múltiples flujos de información entrantes —después de todo, esto es lo que tienen que hacer en el mundo real~\cite{Atki2000}—.
+que los/las estudiantes no deberían intentar conciliar múltiples flujos de información entrantes —después de todo, esto es lo que tienen que hacer en el mundo real~\cite{Atki2000}—.
 En cambio, significa que la instrucción no debería solicitar a las personas
 que lo hagan mientras están incorporando habilidades por primera vez:
 el uso de múltiples fuentes  de información de manera simultánea debe tratarse como una tarea de aprendizaje separada.
 
-\begin{aside}{No todos los gráficos son creados iguales}
+\begin{aside}{No todos los gráficos son equivalentes}
   \cite{Sung2012} presenta un elegante estudio que distingue los gráficos \emph{seductores}\index{graphics!seductive}
   (los cuales son altamente interesantes pero no son directamente relevantes al objetivo de la enseñanza),
   los gráficos\emph{decorativos}\index{graphics!decorative}
@@ -80,18 +80,17 @@ el uso de múltiples fuentes  de información de manera simultánea debe tratars
   y por último
   los gráficos \emph{instructivos}\index{graphics!instructive}
   (los cuales sí son directamente relevantes al objetivo de la enseñanza).
-  Los estudiantes que recibieron cualquier tipo de gráfico obtuvieron calificaciones de satisfacción
-  del material más altas que aquellos que no obtuvieron gráficos,
-  pero en realidad solo las/los estudiantes que obtuvieron gráficos instructivos obtuvieron mejores resultados.
-
-
+  Los/las estudiantes que recibieron cualquier tipo de gráfico calificaron al material
+  con un mayor puntaje, pero en verdad solo quienes recibieron gráficos instructivos
+  obtuvieron mejores resultados.
+  
   Del mismo modo,~\cite{Stam2013,Stam2014} descubrió que
-  tener más información, en realidad puede disminuir el rendimiento.
-  Les mostraron a  niñas/os dibujos, dibujos y números, y simplemente números
-  para dos tareas.
-  Para algunos, tener imágenes o imágenes y números superó al tener solo números,
-  pero para otros, tener imágenes superó a las imágenes y números,
-  lo que superó solo tener números.
+  tener más información en realidad puede disminuir el rendimiento.
+  Les mostraron a niños/as: imágenes, imágenes más números, o simplemente números,
+  para que realicen dos tareas. 
+  Para algunos/as niños/as, recibir imágenes o bien imágenes más números fue mejor que tener únicamente números;
+  pero para otros/as, recibir imágenes superó a tener imágenes más números,
+  lo que superó a solo tener números.
 \end{aside}
 
 \seclbl{Carga cognitiva}{s:architecture-load}
@@ -101,49 +100,48 @@ En~\cite{Kirs2006}, Kirschner, Sweller y Clark escribieron:
 \begin{quote}
  
   Aunque los enfoques educativos no guiados o mínimamente guiados son muy    
-  populares e intuitivamente atractivos{\ldots}estos enfoques ignoran tanto
-  las estructuras que constituyen la arquitectura cognitiva humana como
-  la evidencia de estudios empíricos de los últimos cincuenta años que indican
-  sistemáticamente que la instrucción guiada mínimamente es menos eficaz y
-  menos eficiente que los enfoques educacionales que hacen un fuerte énfasis
-  en la orientación del proceso de aprendizaje del estudiante.
-  La ventaja de la orientación disminuye sólo cuando las/os estudiantes
+  populares e intuitivamente atractivos{\ldots}estos enfoques ignoran 
+  las estructuras que constituyen la arquitectura cognitiva humana así como
+  la evidencia de estudios empíricos de los últimos cincuenta años. Dichas evidencias
+  indican   sistemáticamente que la instrucción guiada mínimamente es menos eficaz y
+  menos eficiente que los enfoques educacionales con un fuerte énfasis
+  en la orientación del proceso de aprendizaje del/de la estudiante.
+  La ventaja de la orientación disminuye sólo cuando los/las estudiantes
   tienen un conocimiento previo suficientemente elevado para proporcionar una orientación ``interna''.
 \end{quote}
 
-Debajo de la jerga,
-los autores afirmaban que el hecho de que las/los estudiantes hagan sus propias preguntas,
+A través de la jerga,
+los autores afirmaban que el hecho de que los/las estudiantes hagan sus propias preguntas,
 establezcan sus propias metas y
 encuentren su propio camino a través de un tema es menos efectivo que mostrarles
 cómo hacer las cosas paso a paso. El enfoque ``elige tu propia aventura'' se conoce como \gref{g:inquiry-based-learning}{aprendizaje basado en la indagación}
 y es intuitivamente atractivo: después de todo,
 ¿quién se \emph{opondría} a tener estudiantes que utilicen su propia iniciativa
 para resolver problemas del mundo real de forma realista?
-Sin embargo, pedir a las/los estudiantes que lo hagan en un nuevo dominio les sobrecarga
-al exigirles que dominen el contenido fáctico de un dominio y sus estrategias de resolución de problemas al mismo tiempo.
+Sin embargo, pedir a los/las estudiantes que lo hagan en un nuevo dominio es una sobrecarga,
+ya que les exige que dominen al mismo tiempo el contenido fáctico de un dominio y las estrategias de resolución de problemas.
 Más específicamente,
 \gref{g:cognitive-load}{la teoría de la carga cognitiva} propone que
-la gente tiene que lidiar con tres cosas cuando está aprendiendo:
+las personas tienen que lidiar con tres cosas cuando está aprendiendo:
 
 
 \begin{description}
 
-\item[\grefdex{g:intrinsic-load}{Carga Intrínseca}{cognitive load!intrinsic}]
-  es lo que la gente tiene que tener en cuenta para aprender el material nuevo.
+\item[\grefdex{g:intrinsic-load}{Carga intrínseca}{cognitive load!intrinsic}]
+  es lo que las personas tienen que tener en cuenta para aprender el material nuevo.
 
-\item[\grefdex{g:germane-load}{Carga Pertinente}{cognitive load!germane}]
+\item[\grefdex{g:germane-load}{Carga pertinente}{cognitive load!germane}]
   es el esfuerzo mental (deseable) requerido para vincular la nueva información con la antigua,
-  que es una de las cosas que distinguen el aprendizaje de la memorización.
+  que es una de las distinciones entre el aprendizaje y la memorización.
 
-
-\item[\grefdex{g:extraneous-load}{Carga Extrínseca}{cognitive load!extraneous}]
-es cualquier cosa que distraiga del aprendizaje.
+\item[\grefdex{g:extraneous-load}{Carga extrínseca}{cognitive load!extraneous}]
+es cualquier cuestión que distraiga del aprendizaje.
 
 \end{description}
 
 La teoría de la carga cognitiva sostiene que
-la gente tiene que dividir una cantidad fija de memoria de trabajo entre estas tres cosas.
-Nuestro objetivo como profesores es maximizar la memoria disponible para manejar la carga intrínseca,
+las personas tienen que dividir una cantidad fija de memoria de trabajo entre estas tres cosas.
+Nuestro objetivo como docentes es maximizar la memoria disponible para manejar la carga intrínseca,
 lo cual significa reducir la carga pertinente en cada paso y eliminar la carga extrínseca.
 
 
@@ -152,7 +150,7 @@ lo cual significa reducir la carga pertinente en cada paso y eliminar la carga e
 Un tipo de ejercicio que puede ser explicado en términos de carga cognitiva
 se utiliza a menudo en la enseñanza de idiomas.
 Supongamos que le pides a alguien que traduzca la frase,
-``¿Cómo está tu rodilla hoy?'' a lengua frisona(frisón).
+``¿Cómo está tu rodilla hoy?'' a lengua frisona.
 Para resolver el problema, necesitan recordar tanto el vocabulario
 como la gramática, que es una carga cognitiva doble.
 Si les pides que pongan ``hoe'', ``har'', ``is'', ``hjoed'' y ``knie'' en el orden correcto,
@@ -160,32 +158,31 @@ por otro lado, les permites que se centren únicamente en el aprendizaje de la g
 Si escribes estas palabras en cinco fuentes o colores diferentes,
 sin embargo, has aumentado la carga cognitiva externa, porque involuntariamente
 (y posiblemente de manera inconsciente) invertirán algo de esfuerzo tratando de averiguar
-si las diferencias son significativas (\figref{f:architecture-frisian}).
+si las diferencias entre las palabras son significativas de acuerdo a sus colores (\figref{f:architecture-frisian}).
 
 \figimg{figures/frisian.png}{Construyendo una oración}{f:architecture-frisian}
 
-El equivalente de codificación de este
-se llama \gref{g:parsons-problem}{Problema de Parsons}\footnote{Nombrado debido a uno de sus creadores.}~\cite{Pars2006}.
+El equivalente de codificación de este ejemplo
+se llama \gref{g:parsons-problem}{problema de Parsons}\footnote{Nombrado así debido a uno de sus creadores.}~\cite{Pars2006}.
 
-Cuando se enseña a la gente a programar,
-puedes darles las líneas de código que necesitan para resolver un problema
-y pedirles que las pongan en el orden correcto.
-Esto les permite concentrarse en el flujo de control y las dependencias de datos
+Cuando enseñes a programar,
+puedes darles a tus estudiantes las líneas de código que necesitan para resolver un problema
+y pedirles que las ordenen en el orden correcto.
+Esto les permite concentrarse en el flujo de control y en las dependencias de datos,
 sin distraerse con la denominación de las variables o tratando de recordar qué funciones llamar.
-Múltiples estudios han demostrado que los problemas de Parsons les toma a los estudiantes menos tiempo resolverlo
-pero producen resultados educativos equivalentes~\cite{Eric2017}.
+Múltiples estudios han demostrado que los problemas de Parsons demandan menos tiempo de resolución pero producen resultados educativos equivalentes~\cite{Eric2017}.
 
 
 \subsection*{Ejemplos desvanecidos}
 
 Otro tipo de ejercicio que se puede explicar en términos de carga cognitiva
-es dar a las/los estudiantes una serie de ejemplos desvanecidos \grefdex{g:faded-example}{faded examples}{faded example}.
+es dar a tus estudiantes una serie de ejemplos desvanecidos \grefdex{g:faded-example}{faded examples}{faded example}.
 El primer ejemplo de una serie presenta un uso completo de una estrategia
 particular de resolución de problemas.
 El siguiente problema es del mismo tipo,
-pero tiene algunas lagunas que el estudiante debe llenar.
-Cada problema sucesivo le da al estudiante menos \gref{g:scaffolding}{scaffolding},
-hasta que se le pide que resuelva un problema completo desde cero.
+pero tiene algunas lagunas que tu estudiante debe llenar.
+Cada problema sucesivo da menos \gref{g:scaffolding}{scaffolding},
+hasta que se pide resolver un problema completo desde cero.
 Al enseñar álgebra en la escuela secundaria,
 por ejemplo,
 podríamos comenzar con esto:
@@ -204,7 +201,7 @@ podríamos comenzar con esto:
 \end{center}
 
 \noindent
-y luego pide a las/los estudiantes que resuelvan esto:
+y luego pedir que los/las estudiantes resuelvan esto:
 
 \begin{center}
 \begin{tabular}{rcl}
@@ -230,7 +227,7 @@ y esto:
 \end{center}
 
 \noindent
-y finalmente, esto:
+y, finalmente, esto:
 
 \begin{center}
 \begin{tabular}{rcl}
@@ -253,7 +250,7 @@ define total_length(list_of_words):
 
 \noindent
 
-y luego pídales que llenen los espacios en blanco en esto
+y luego pidiendo que llenen los espacios en blanco aquí
 (lo que centra su atención en las estructuras de control):
 
 
@@ -278,7 +275,7 @@ define join_all(list_of_words):
     return joined_words
 \end{minted}
 
-Finalmente, se pedirá a las/los estudiantes que escriban una función completa por su cuenta:
+Finalmente, los/las estudiantes tendrán que escribir una función completa por su cuenta:
 
 \begin{minted}{text}
 # make_acronym(["red", "green", "blue"]) => "RGB"
@@ -287,17 +284,17 @@ define make_acronym(list_of_words):
 \end{minted}
 
 Los ejemplos difusos funcionan porque
-presentan la estrategia de resolución de problemas pieza por pieza:
-en cada paso,
-las/los estudiantes tienen un nuevo problema que abordar,
-que es menos intimidante que una pantalla en blanco o una hoja de papel en blanco (\secref{s:classroom-practices}).
-También anima a las/los estudiantes a pensar en las similitudes y diferencias entre varios enfoques,
-lo que ayuda a crear los vínculos en sus modelos mentales que ayudan a la recuperación de la información.
+presentan la estrategia de resolución de problemas fragmento por fragmento.
+En cada paso,
+los/las estudiantes tienen un nuevo problema que abordar,
+lo cual es menos intimidante que una pantalla en blanco o una hoja de papel en blanco (\secref{s:classroom-practices}).
+También anima a que los/las estudiantes piensen en las similitudes y diferencias entre varios enfoques,
+lo que ayuda a crear los vínculos en sus modelos mentales y desde modo facilita la recuperación de la información.
 
 La clave para construir un buen ejemplo desvanecido es
 pensar en la estrategia de resolución de problemas que se pretende enseñar.
 Por ejemplo,
-los problemas de programación sobre todo utilizan el patrón de diseño del acumulador,
+los problemas de programación sobre todo utilizan el patrón de diseño acumulativo,
 en el que los resultados del procesamiento de elementos de una colección
 se agregan repetidamente a una sola variable de alguna manera para crear el resultado final.
 

--- a/es/architecture.tex
+++ b/es/architecture.tex
@@ -462,7 +462,7 @@ o cuántas veces aparecen palabras diferentes en un párrafo de texto.
 \item
     Define el público de tus ejemplos.
     Por ejemplo,
-    ¿son  personas principiantes que solo conocen algunos conceptos básicos de programación?
+    ¿son personas principiantes que solo conocen algunos conceptos básicos de programación?
     ¿O son estudiantes con alguna experiencia en programación?
 
 \item

--- a/es/architecture.tex
+++ b/es/architecture.tex
@@ -62,7 +62,7 @@ supera el esfuerzo de procesamiento adicional.
   fragmento a fragmento mientras enseñas, en lugar de presentar todo el gráfico de una sola vez.
   Si las partes de un diagrama aparecen al mismo tiempo en que los gráficos son explicados,
   el/la estudiante correlaciona ambos elementos en su memoria.
-  Así, al luego enfocarte en una parte del diagrama es más probable que tu estudiante active la recuperación
+  Así que luego, al enfocarte en una parte del diagrama es más probable que tu estudiante active la recuperación
   de lo que fue dicho cuando esa parte fue dibujada.
 \end{aside}
 

--- a/es/architecture.tex
+++ b/es/architecture.tex
@@ -303,7 +303,7 @@ se agregan repetidamente a una sola variable de alguna manera para crear el resu
   Un modelo alternativo de aprendizaje e instrucción que también usa andamiaje y desvanecimiento
   es el \gref{g:cognitive-apprenticeship}{aprendizaje cognitivo},
   que enfatiza la forma en que un/a docente transmite habilidades y conocimientos a un/a aprendiz.
-  El/la maestro/a proporciona modelos de desempeño y resultados,
+  El/la docente proporciona modelos de desempeño y resultados,
   luego entrena a las personas novatas explicando qué están haciendo y por qué~\cite{Coll1991,Casp2007}.
   El/la aprendiz reflexiona sobre su propia resolución de problemas,
   por ejemplo, pensando en voz alta o criticando su propio trabajo,

--- a/es/architecture.tex
+++ b/es/architecture.tex
@@ -62,7 +62,7 @@ supera el esfuerzo de procesamiento adicional.
   fragmento a fragmento mientras enseñas, en lugar de presentar todo el gráfico de una sola vez.
   Si las partes de un diagrama aparecen al mismo tiempo en que los gráficos son explicados,
   el/la estudiante correlaciona ambos elementos en su memoria.
-  Así que luego, al enfocarte en una parte del diagrama es más probable que tu estudiante active la recuperación
+  Así que luego, al enfocarte en una parte del diagrama, es más probable que tu estudiante active la recuperación
   de lo que fue dicho cuando esa parte fue dibujada.
 \end{aside}
 

--- a/es/architecture.tex
+++ b/es/architecture.tex
@@ -156,7 +156,7 @@ como la gramática, que es una carga cognitiva doble.
 Si les pides que pongan ``hoe'', ``har'', ``is'', ``hjoed'' y ``knie'' en el orden correcto,
 por otro lado, les permites que se centren únicamente en el aprendizaje de la gramática.
 Si escribes estas palabras en cinco fuentes o colores diferentes,
-sin embargo, has aumentado la carga cognitiva externa, porque involuntariamente
+sin embargo, has aumentado la carga cognitiva extrínseca, porque involuntariamente
 (y posiblemente de manera inconsciente) invertirán algo de esfuerzo tratando de averiguar
 si las diferencias entre las palabras son significativas de acuerdo a sus colores (\figref{f:architecture-frisian}).
 
@@ -302,34 +302,34 @@ se agregan repetidamente a una sola variable de alguna manera para crear el resu
 \begin{aside}{Aprendizaje cognitivo}
   Un modelo alternativo de aprendizaje e instrucción que también usa andamiaje y desvanecimiento
   es el \gref{g:cognitive-apprenticeship}{aprendizaje cognitivo},
-  que enfatiza la forma en que un maestro transmite habilidades y conocimientos a un aprendiz.
-  El maestro proporciona modelos de desempeño y resultados,
-  luego entrena a las/los principiantes explicando qué están haciendo y por qué~\cite{Coll1991,Casp2007}.
-  El aprendiz reflexiona sobre su propia resolución de problemas,
+  que enfatiza la forma en que un/a maestro/a transmite habilidades y conocimientos a un aprendiz.
+  El/la maestro/a proporciona modelos de desempeño y resultados,
+  luego entrena a las personas novatas explicando qué están haciendo y por qué~\cite{Coll1991,Casp2007}.
+  El/la aprendiz reflexiona sobre su propia resolución de problemas,
   por ejemplo, pensando en voz alta o criticando su propio trabajo,
   y finalmente explora problemas de su propia elección.
 
   Este modelo nos dice que
-  las/los profesores deben presentar varios ejemplos al explicar una nueva idea
-  para que las/los estudiantes puedan ver qué generalizar,
+  los/las docentes deben presentar varios ejemplos al explicar una nueva idea
+  para que los/las estudiantes puedan ver qué generalizar,
   y que deben variar la forma del problema para dejar en claro
-  cuáles son y cuáles no son características superficiales features\footnote{Por mucho tiempo,
+  cuáles son y cuáles no son características superficiales\footnote{Por mucho tiempo
      creí que la variable que contenía el valor que una función iba a devolver
-     \emph{tenía} que llamarse \texttt{resultado}
+     \emph{tenía} que llamarse \texttt{resultado},
      porque mi maestro siempre usaba ese nombre en los ejemplos.}.    
   Los problemas deben presentarse en contextos del mundo real,
-  y debemos fomentar la autoexplicación para ayudar a las/los estudiantes
+  y debemos fomentar la autoexplicación para ayudar a los/las estudiantes
   a organizarse y dar sentido a lo que se les acaba de enseñar
  (\secref{s:individual-strategies}).
 \end{aside}
 
 
-\subsection*{Subobjetivos etiquetados}
+\subsection*{Sub\-objetivos etiquetados}
  
-\grefdex{g:subgoal-labeling}{Labeling subgoals}{labeled subgoals} significa
+\grefdex{g:subgoal-labeling}{Etiquetar sub\-objetivos}{labeled subgoals} significa
 dar nombre a los pasos en una descripción paso a paso de un proceso de resolución de problemas.
-\cite{Marg2016,Morr2016} descubrieron que los estudiantes con subobjetivos etiquetados
-resolvían los problemas de Parsons mejor que las/los estudiantes sin estos,
+\cite{Marg2016,Morr2016} descubrieron que al etiquetar los sub\-objetivos, los/las estudiantes 
+resolvían mejor los problemas de Parsons,
 y se observa el mismo beneficio en otros dominios~\cite{Marg2012}.
 Volviendo al ejemplo de Python usado anteriormente,
 los objetivos secundarios para encontrar la longitud total de una lista de palabras o construir un acrónimo son:
@@ -337,21 +337,21 @@ los objetivos secundarios para encontrar la longitud total de una lista de palab
 \begin{enumerate}
 
 \item
-  Crea un valor vacío del tipo que se devolverá.
+  Crea un valor vacío del tipo a obtener.
 
 \item
-  Obtiene el valor que se agregará al resultado de la variable de ciclo.
+  A partir de la variable del bucle, obtén el valor que se agregará al resultado.
 
 \item
   Actualiza el resultado con ese valor.
 
 \end{enumerate}
 
-Etiquetar subobjetivos funciona porque agrupar los pasos relacionados en fragmentos con nombre(\secref{s:memory-seven-plus-or-minus})\index{chunking}
-ayuda a las/los estudiantes a distinguir lo que es genérico de lo que es específico del problema en cuestión.
-También les ayuda a construir un modelo mental de ese tipo de problema
-para que puedan resolver otros problemas de ese tipo
-y les da una oportunidad natural para la autoexplicación (\secref{s:individual-strategies}).
+Etiquetar sub\-objetivos funciona porque agrupar los pasos relacionados en fragmentos con nombre (\secref{s:memory-seven-plus-or-minus})\index{chunking}
+ayuda a tus estudiantes a distinguir lo que es genérico de lo que es específico del problema en cuestión.
+También les ayuda a construir un modelo mental de ese tipo de problema,
+de modo que luego pueden resolver otros problemas de ese tipo,
+y les da una oportunidad natural para la auto\-explicación (\secref{s:individual-strategies}).
 
 \subsection*{Manuales mínimos}
 
@@ -371,55 +371,55 @@ independientemente de la experiencia previa con computadoras~\cite{Lazo1993}.
 
 \begin{quote}
 
-  Nuestros diseños ``minimalistas'' buscaban aprovechar la iniciativa del usuario y el conocimiento previo,
+  Nuestros diseños ``minimalistas'' buscaban aprovechar la iniciativa de cada usuario/a y el conocimiento previo,
   en lugar de controlarlo mediante advertencias y pasos ordenados.
-  Enfatizó que los usuarios generalmente aportan mucha experiencia y conocimiento a este aprendizaje,
+  Se enfatizaba que los/las usuarios/as generalmente aportan mucha experiencia y conocimiento a este aprendizaje,
   por ejemplo,
   conocimiento sobre el dominio de la tarea,
-  y que dicho conocimiento podría ser un recurso para los diseñadores instruccionales.
+  y que dicho conocimiento podría ser un recurso para los/as diseñadores de instructivos.
   El minimalismo aprovechó los episodios de reconocimiento, diagnóstico y corrección de errores,
-  en lugar de intentar simplemente prevenirlos.
-  Enmarca la resolución de problemas y la corrección como oportunidades de aprendizaje en lugar de aberraciones.
+  en lugar de intentar simplemente prevenirlos. Es decir,
+  enmarcó la resolución de problemas y la corrección como oportunidades de aprendizaje en lugar de aberraciones.
 
 \end{quote}
 
 
 \seclbl{Otros modelos de aprendizaje}{s:architecture-theory}
 
-Los críticos de la teoría de la carga cognitiva a veces han argumentado que\index{cognitive load!criticism of}
-cualquier resultado puede justificarse a posteriori al etiquetar las cosas que perjudican el rendimiento como cargas extrañas
-y las que no lo hacen como intrínsecas o pertinentes.
+Quienes critican la teoría de la carga cognitiva a veces han argumentado que\index{cognitive load!criticism of}
+cualquier resultado puede justificarse \emph{a posteriori} al etiquetar como carga extrínseca a
+aquello que perjudica el rendimiento 
+y como carga intrínseca o pertinente a aquello que no lo perjudica..
 Sin embargo,
 la instrucción basada en la teoría de la carga cognitiva es innegablemente efectiva.
 Por ejemplo,
 \cite{Maso2016} rediseñó un curso de base de datos para eliminar la atención dividida y los efectos de redundancia
 y para proporcionar ejemplos prácticos y subobjetivos.
 El nuevo curso redujo la tasa de reprobación del examen en un 34\%
-y aumentó la satisfacción del estudiante.
-
+y aumentó la satisfacción de los/las estudiantes.
 
 Una década después de la publicación de~\cite{Kirs2006},
 un número creciente de personas cree que la teoría de la carga cognitiva y los enfoques basados ​​en la investigación son compatibles
 si se ven de la manera correcta.
 \cite{Kaly2015} sostiene que la teoría de la carga cognitiva es básicamente una microgestión del aprendizaje
-dentro de un contexto más amplio que considera cosas como la motivación,
+dentro de un contexto más amplio que considera cuestiones como la motivación,
 mientras que~\cite{Kirs2018} extiende la teoría de la carga cognitiva para incluir aspectos colaborativos del aprendizaje.
 Al igual que con~\cite{Mark2018} (discutido en \secref{s:individual-strategies}),
-las perspectivas de los investigadores pueden diferir,
+las perspectivas de los/las investigadores/as pueden diferir,
 pero la implementación práctica de sus teorías a menudo termina siendo la misma.
 
 Uno de los desafíos en la investigación educativa es que
 lo que queremos decir con ``aprendizaje'' resulta complicado
 una vez que se mira más allá del aula occidental estandarizada.
 Dos perspectivas específicas de la \gref{g:educational-psychology}{psicología educativa} han influido en este libro.
-El que hemos utilizado hasta ahora es el \gref{g:cognitivism}{cognitivismo},
-que se centra en cosas como el reconocimiento de patrones, la formación de la memoria y el recuerdo.
+La que hemos utilizado hasta ahora es el \gref{g:cognitivism}{cognitivismo},
+que se centra en conceptos como el reconocimiento de patrones, la formación de la memoria y el recuerdo.
 Es bueno para responder preguntas de bajo nivel,
 pero generalmente ignora cuestiones más importantes como,
 ``¿Qué queremos decir con 'aprendizaje'?'' y
-``¿Quién decide?''
-El otro es el \gref{g:situated-learning}{aprendizaje situado},
-que se centra en llevar a las personas a una comunidad
+``¿Quién tiene poder de decisión?''
+La segunda perspectiva utilizada es el \gref{g:situated-learning}{aprendizaje situado},
+que se centra en integrar a las personas en una comunidad
 y reconoce que
 la enseñanza y el aprendizaje siempre están arraigados en quiénes somos y quiénes aspiramos a ser.
 Lo discutiremos con más detalle en el \chapref{s:community}.
@@ -428,56 +428,56 @@ Lo discutiremos con más detalle en el \chapref{s:community}.
 El sitio web de \hreffoot{http://www.learning-theories.com/}{Learning Theories, teorías de aprendizaje en inglés}
 y~\cite{Wibu2016}
 tienen buenos resúmenes de estas y otras perspectivas.
-Además del cognitivismo, los que se encuentran con mayor frecuencia incluyen el \gref{g:behaviorism}{conductismo}
+Además del cognitivismo, las que se encuentran con mayor frecuencia incluyen el \gref{g:behaviorism}{conductismo}
 (que trata la educación como un condicionamiento de estímulo/respuesta),
 el \gref{g:constructivism}{constructivismo}
-(que considera el aprendizaje como un proceso activo durante el cual las/los estudiantes construyen conocimiento por sí mismos)
+(que considera al aprendizaje como un proceso activo durante el cual los/las estudiantes construyen conocimiento por sí mismos)
 y el \gref{g:connectivism}{conectivismo}.
 (que sostiene que el conocimiento se distribuye,
 que el aprendizaje es el proceso de navegar, crecer y podar conexiones,
-y que enfatiza los aspectos sociales del aprendizaje que Internet hace posible).
+y que enfatiza los aspectos sociales del aprendizaje que internet hace posible).
 Estas perspectivas pueden ayudarnos a organizar nuestros pensamientos,
-pero en la práctica,
-siempre tenemos que probar nuevos métodos en la clase,
+pero en la práctica
+siempre tenemos que probar nuevos métodos en clase,
 con estudiantes reales,
 para descubrir qué tan bien equilibran las muchas fuerzas en juego.
 
 \seclbl{Ejercicios}{s:architecture-exercises}
 
-\exercise{Crear un ejemplo desvanecido}{pares}{30'}
+\exercise{Crear un ejemplo desvanecido}{parejas}{30'}
 
-Es muy común que los programas cuenten cuántas cosas caen en diferentes categorías:
+Es muy común que en los programas se cuenten cuántas cosas caen en diferentes categorías:
 por ejemplo,
 cuántas veces aparecen colores diferentes en una imagen
 o cuántas veces aparecen palabras diferentes en un párrafo de texto.
 
 \begin{enumerate}
 \item
-    Crea un ejemplo breve (no más de 10 líneas de código) que muestre a las personas cómo hacer esto,
-    y luego crea un segundo ejemplo que resuelva un problema similar de una manera similar
-    pero que tenga un par de espacios en blanco para que las/los estudiantes los completen.
-    ¿Decides qué desvanecer?
+    Crea un ejemplo breve (no más de 10 líneas de código) que muestre a las personas cómo hacer esto.
+    Luego, crea un segundo ejemplo que resuelva un problema similar de una manera similar,
+    pero que tenga un par de espacios en blanco para que los/las estudiantes los completen.
+    ¿Cómo decides qué desvanecer?
     ¿Cuál sería el siguiente ejemplo de la serie?
 
 \item
-    Define la audiencia de sus ejemplos.
+    Define el público de tus ejemplos.
     Por ejemplo,
-    ¿son  principiantes que solo conocen algunos conceptos básicos de programación?
-    ¿O son estudiantes tienen alguna experiencia en programación?
+    ¿son  personas principiantes que solo conocen algunos conceptos básicos de programación?
+    ¿O son estudiantes con alguna experiencia en programación?
 
 \item
     Muestra tu ejemplo a tu pareja,
-    pero no le digas para qué nivel crees que es.
-    Una vez que hayan llenado los espacios en blanco,
-    pídeles que adivinen el nivel deseado.
+    pero \emph{no} le digas para qué nivel crees que es.
+    Una vez que tu pareja haya llenado los espacios en blanco,
+    pídele que adivine el nivel de estudiante previsto.
 
 \end{enumerate}
 
-Si hay personas entre los aprendices que no programan en absoluto,
+Si entre tus estudiantes hay personas que no programan en absoluto,
 intenta ubicarlos en diferentes grupos
 y pídeles que hagan el papel de aprendices para esos grupos.
 Alternativamente,
-elije un dominio de problema diferente y desarrolla un ejemplo difuso para él.
+elige un dominio de problema diferente con el que desarrollar tu ejemplo desvanecido.
 
 
 \exercise{Clasificación de carga}{grupos pequeños}{15'}
@@ -485,33 +485,33 @@ elije un dominio de problema diferente y desarrolla un ejemplo difuso para él.
 \begin{enumerate}
 
 \item
-  Elige una lección corta que un miembro de tu grupo haya enseñado o tomado recientemente.
+  Elige una lección corta que alguna persona de tu grupo haya enseñado o tomado recientemente.
 
 \item
-  Haz una lista en forma de puntos de las ideas, instrucciones y explicaciones que contiene.
+  Haz un listado con viñetas de las ideas, instrucciones y explicaciones que contiene la lección.
 
 \item
-  Clasifica cada uno como intrínseco, pertinente o extraño.
-  ¿En qué partes estaban todos de acuerdo?
-  ¿Dónde estuvo en desacuerdo y por qué?
+  Clasifica cada elemento de tu listado como carga intrínseca, pertinente o extrínseca.
+  ¿En qué ítems todas las personas del grupo estuvieron de acuerdo?
+  ¿En cuáles estuvieron en desacuerdo y por qué?
 
 \end{enumerate}
 
-(El ejercicio ``Cómo darse cuenta de su punto ciego'' en \secref{s:memory-exercises}
-le dará una idea de cuán detallada debe ser su lista de formularios de puntos).
+(El ejercicio ``Notar tus puntos ciegos'' en \secref{s:memory-exercises}
+te dará una idea de cuán detallado debe ser tu listado de ítems).
 
 
 \exercise{Crear un problema de Parsons}{en parejas}{20'}
 
 Escribe cinco o seis líneas de código que hagan algo útil,
-mezclalas y pídele a tu compañero que las ponga en orden.
-Si estás utilizando un lenguaje basado en identación como Python,
+mézclalas y pídele a tu pareja que las ponga en orden.
+Si estás utilizando un lenguaje basado en indentación como Python,
 no utilices sangría en ninguna de las líneas;
 si estás utilizando un lenguaje de llaves como Java,
 no incluyas ninguna de las llaves.
-(Si tu grupo incluye personas que no son programadores,
+(Si tu grupo incluye personas que no programan,
 usa un dominio de problema diferente,
-como hacer budín/pan de plátano).
+como hacer pan de banana).
 
 
 \exercise{Manuales mínimos}{individual}{20'}
@@ -519,7 +519,7 @@ como hacer budín/pan de plátano).
 Escribe una guía de una página para hacer algo que tus estudiantes puedan encontrar en una de tus clases,
 como centrar el texto horizontalmente
 o imprimir un número con un cierto número de dígitos después del punto decimal.
-Intentá enumerar al menos tres o cuatro resultados incorrectos que el estudiante pueda ver
+Intenta enumerar al menos tres o cuatro resultados incorrectos que tu estudiante pueda obtener
 e incluye una explicación de una o dos líneas
 de por qué ocurre cada uno y cómo corregirlo.
 
@@ -528,21 +528,21 @@ de por qué ocurre cada uno y cómo corregirlo.
 
 Elige un problema de codificación que puedas resolver en dos o tres minutos
 y piensa en voz alta mientras lo resuelves,
-al mismo tiempo tu compañero te hace preguntas sobre lo que estás haciendo y por qué.
+al mismo tiempo tu pareja te hace preguntas sobre lo que estás haciendo y por qué.
 No solo explica lo que estás haciendo,
 sino también por qué lo estás haciendo,
 cómo sabes que es lo correcto y qué alternativas has considerado pero descartado.
 Cuando hayas terminado,
-intercambia roles con tu compañero y repite el ejercicio.
+intercambia roles con tu pareja y repite el ejercicio.
 
 
 \exercise{Ejemplos resueltos}{parejas}{15'}
 
 Ver ejemplos resueltos ayuda a las personas a aprender a programar más rápido que simplemente escribiendo mucho código~\cite{Skud2014},
-y deconstruir/desagregar el código rastreándolo o depurándolo también aumenta el aprendizaje~\cite{Grif2016}.
+y deconstruir el código rastreándolo o depurándolo también aumenta el aprendizaje~\cite{Grif2016}.
 Trabajando en parejas, revisa un fragmento de código de 10 a 15 líneas
 y explica qué hace cada declaración y por qué es necesaria.
-¿Cuánto tiempo te tardas?
+¿Cuánto tiempo demoras?
 ¿Cuántas cosas crees que necesitas explicar por línea de código?
 
 \exercise{Gráficos críticos}{individual}{30'}
@@ -556,30 +556,30 @@ y explica qué hace cada declaración y por qué es necesaria.
   para que se destaquen del material menos crítico.
 
 \item[Contigüidad espacial:]
-  coloca los subtítulos lo más cerca posible de los gráficos para compensar el costo de cambiar entre los dos.
+  coloca los subtítulos lo más cerca posible de los gráficos para compensar el costo de cambiar entre la imagen y el texto.
 
 \item[Contigüidad temporal:]
-  Presenta narraciones y gráficos hablados tan seguidos en el tiempo como sea práctico.
+  Presenta narraciones habladas y gráficos tan seguidos en el tiempo como sea práctico.
   (Presentar ambos a la vez es mejor que presentarlos uno tras otro).
 
 \item[Segmentación:]
   Cuando presentes una secuencia larga de material o
-  cuando los estudiantes no tengan experiencia con el tema,
+  cuando tus estudiantes no tengan experiencia en el tema,
   divide la presentación en segmentos cortos y deja que los estudiantes controlen la rapidez con que avanzan al siguiente.
 
 \item[Pre-entrenamiento:]
-  Si los estudiantes no conocen los conceptos y la terminología principales utilizados en tu presentación,
+  Si tus estudiantes no conocen los conceptos y la terminología principales que utilizas en la presentación,
   enseña solo esos conceptos y términos de antemano.
 
 \item[Modalidad:]
-las personas aprenden mejor de las imágenes más la narración que de las imágenes más el texto,
-a menos que no sean hablantes nativos o haya palabras o símbolos técnicos.
+las personas aprenden mejor de las imágenes con narración que de las imágenes con texto,
+a menos que no sean hablantes nativas del idioma de la lección o que haya palabras o símbolos técnicos.
 
 \end{description}
 
 Elige un video de una lección o charla en línea que utilice diapositivas u otras presentaciones estáticas
-y califique sus gráficos como ``deficientes'', ``promedio'' o ``buenos'' de acuerdo con estos seis criterios.
+y califica sus gráficos como ``deficientes'', ``promedio'' o ``buenos'' de acuerdo con estos seis criterios.
 
 \section*{Revisión}
 
-\figpdfhere{figures/conceptmap-cognitive-load.pdf}{Concepto: Carga congnitiva}{f:architecture-cognitive-load}
+\figpdfhere{figures/conceptmap-cognitive-load.pdf}{Conceptos: carga cognitiva}{f:architecture-cognitive-load}

--- a/es/architecture.tex
+++ b/es/architecture.tex
@@ -3,7 +3,7 @@
 Hemos hablado acerca de modelos mentales como si fueran cosas reales,
 pero ¿qué es lo que realmente sucede en el cerebro de una persona cuando está aprendiendo?
 La respuesta corta es que no lo sabemos, la respuesta larga es que sabemos mucho más que antes.
-Este capítulo profundizará en qué hace el cerebro hace mientras el aprendizaje sucede
+Este capítulo profundizará en qué hace el cerebro mientras el aprendizaje sucede
 y en cómo podemos aprovecharlo para diseñar y brindar lecciones de manera más efectiva.
 
 \seclbl{¿Qué es lo que sucede allí?}{s:architecture-brain}

--- a/es/architecture.tex
+++ b/es/architecture.tex
@@ -149,14 +149,14 @@ lo cual significa reducir la carga pertinente en cada paso y eliminar la carga e
 
 Un tipo de ejercicio que puede ser explicado en términos de carga cognitiva
 se utiliza a menudo en la enseñanza de idiomas.
-Supongamos que le pides a alguien que traduzca la frase,
-``¿Cómo está tu rodilla hoy?'' a lengua frisona.
+Supongamos que le pides a alguien que traduzca la frase
+``¿Cómo está tu rodilla hoy?'' de castellano a catalán.
 Para resolver el problema, necesitan recordar tanto el vocabulario
 como la gramática, que es una carga cognitiva doble.
-Si les pides que pongan ``hoe'', ``har'', ``is'', ``hjoed'' y ``knie'' en el orden correcto,
-por otro lado, les permites que se centren únicamente en el aprendizaje de la gramática.
-Si escribes estas palabras en cinco fuentes o colores diferentes,
-sin embargo, has aumentado la carga cognitiva extrínseca, porque involuntariamente
+Si, en lugar de traducir desde cero, les pides que pongan ``com'', ``està'', ``el'', ``teu'', ``genoll'' y ``avui'' en el orden correcto,
+les permites que se centren únicamente en el aprendizaje de la gramática.
+Sin embargo, si escribes estas palabras en seis fuentes o colores diferentes,
+has aumentado la carga cognitiva extrínseca, porque involuntariamente
 (y posiblemente de manera inconsciente) invertirán algo de esfuerzo tratando de averiguar
 si las diferencias entre las palabras son significativas de acuerdo a sus colores (\figref{f:architecture-frisian}).
 

--- a/es/architecture.tex
+++ b/es/architecture.tex
@@ -110,8 +110,8 @@ En~\cite{Kirs2006}, Kirschner, Sweller y Clark escribieron:
   tienen un conocimiento previo suficientemente elevado para proporcionar una orientación ``interna''.
 \end{quote}
 
-A través de la jerga,
-los autores afirmaban que el hecho de que los/las estudiantes hagan sus propias preguntas,
+Más allá de la jerga,
+lo que estos autores afirmaban es que el hecho de que los/las estudiantes hagan sus propias preguntas,
 establezcan sus propias metas y
 encuentren su propio camino a través de un tema es menos efectivo que mostrarles
 cómo hacer las cosas paso a paso. El enfoque ``elige tu propia aventura'' se conoce como \gref{g:inquiry-based-learning}{aprendizaje basado en la indagación}

--- a/es/architecture.tex
+++ b/es/architecture.tex
@@ -389,7 +389,7 @@ independientemente de la experiencia previa con computadoras~\cite{Lazo1993}.
 Quienes critican la teoría de la carga cognitiva a veces han argumentado que\index{cognitive load!criticism of}
 cualquier resultado puede justificarse \emph{a posteriori} al etiquetar como carga extrínseca a
 aquello que perjudica el rendimiento 
-y como carga intrínseca o pertinente a aquello que no lo perjudica..
+y como carga intrínseca o pertinente a aquello que no lo perjudica.
 Sin embargo,
 la instrucción basada en la teoría de la carga cognitiva es innegablemente efectiva.
 Por ejemplo,

--- a/es/architecture.tex
+++ b/es/architecture.tex
@@ -431,7 +431,7 @@ tienen buenos resúmenes de estas y otras perspectivas.
 Además del cognitivismo, las que se encuentran con mayor frecuencia incluyen el \gref{g:behaviorism}{conductismo}
 (que trata la educación como un condicionamiento de estímulo/respuesta),
 el \gref{g:constructivism}{constructivismo}
-(que considera al aprendizaje como un proceso activo durante el cual los/las estudiantes construyen conocimiento por sí mismos)
+(que considera al aprendizaje como un proceso activo durante el cual los/las estudiantes construyen conocimiento por sí mismos/as)
 y el \gref{g:connectivism}{conectivismo}.
 (que sostiene que el conocimiento se distribuye,
 que el aprendizaje es el proceso de navegar, crecer y podar conexiones,

--- a/es/architecture.tex
+++ b/es/architecture.tex
@@ -1,17 +1,17 @@
 \chapter{Arquitectura cognitiva}\label{s:architecture}
 
 Hemos hablado acerca de modelos mentales como si fueran cosas reales,
-pero ¿qué es lo que realmente sucede en el cerebro de un aprendiz cuando está aprendiendo?
+pero ¿qué es lo que realmente sucede en el cerebro de una persona cuando está aprendiendo?
 La respuesta corta es que no lo sabemos, la respuesta larga es que sabemos mucho más que antes.
-Este capítulo profundizará en lo que el cerebro hace mientras el aprendizaje sucede
-y cómo podemos aprovechar eso para diseñar y brindar lecciones de manera más efectiva.
+Este capítulo profundizará en qué hace el cerebro hace mientras el aprendizaje sucede
+y en cómo podemos aprovecharlo para diseñar y brindar lecciones de manera más efectiva.
 
 \seclbl{¿Qué es lo que sucede allí?}{s:architecture-brain}
 
-\figpdf{figures/cognitive-architecture.pdf}{Arquitectura Cognitiva}{f:arch-model}
+\figpdf{figures/cognitive-architecture.pdf}{Arquitectura cognitiva}{f:arch-model}
 
 La figura \figref{f:arch-model} es un modelo simplificado de la arquitectura cognitiva humana. \index{cognitive architecture}
-El núcleo de este modelo es la separación entre la memoria a corto y a largo plazo vistas en \secref{s:memory-seven-plus-or-minus}.
+El núcleo de este modelo es la separación entre la memoria a corto y a largo plazo vistas en la \secref{s:memory-seven-plus-or-minus}.
 La memoria a largo plazo es como tu sótano:\index{long-term memory}
 almacena objetos de forma más o menos permanente
 pero tu conciencia no puede acceder a ella directamente.
@@ -33,46 +33,46 @@ y del canal visual\index{visual channel}
 (para las imágenes)\footnote{
   Un modelo más completo
   también incluiría el sentido del tacto, del olfato y del gusto,
-  pero por ahora, los ignoraremos.}.
-La mayoría de las personas confía principalmente en su canal visual,
-pero cuando las imágenes y las palabras se complementan entre sí,
-el cerebro hace un mejor trabajo al recordarlas a ambas:
+  pero por ahora los ignoraremos.}.
+Si bien la mayoría de las personas confía principalmente en su canal visual,
+cuando las imágenes y las palabras se complementan entre sí
+el cerebro hace un mejor trabajo al recordarlas:
 se codifican juntas,
-de modo que el recuerdo de una más tarde ayude a activar el recuerdo de la otra.
+de modo que el recuerdo de una más tarde ayuda a activar el recuerdo de la otra.
 
-Las entradas lingüísticas y visuales son procesadas por diferentes partes del cerebro humano,
+Las entradas lingüísticas y visuales son procesadas por diferentes partes del cerebro humano
 y a su vez los recuerdos lingüísticos y visuales son almacenados también de manera separada.
 Esto significa que correlacionar flujos de información lingüísticos y visuales requiere esfuerzo cognitivo:
 si alguien lee algo mientras lo escucha en voz alta,
 su cerebro no puede evitar comprobar que obtiene la misma información por ambos canales.
 
 Por lo tanto, el aprendizaje aumenta cuando la información se presenta de manera simultánea por dos canales diferentes,
-pero se reduce cuando esa información es redundante, en lugar de ser complementaria,
+pero se reduce cuando esa información es redundante, en lugar de ser complementaria:
 tal fenómeno es conocido como \gref{g:split-attention-effect}{efecto de atención dividida}~\cite{Maye2003}.
 Por ejemplo, en general las personas encuentran más difícil aprender de un video que tiene narración y
-al mismo tiempo capturas de pantalla que de uno que solo tiene narración o capturas (pero no ambos elementos),
+al mismo tiempo capturas de pantalla que de uno que únicamente tiene narración o capturas (pero no ambos elementos),
 porque en el primer caso parte de su atención ha sido utilizada para chequear que la narración  
-y las capturas se correspondan entre sí. Dos notables excepciones a esto,
+y las capturas se correspondan entre sí. Dos notables excepciones 
 son las personas que aún no hablan bien un idioma y las que tienen algún impedimento auditivo u
 otras necesidades especiales, quienes quizás encuentren que el valor de la información redundante
 supera el esfuerzo de procesamiento adicional.
 
-\begin{aside}{Pieza por pieza}
-  El efecto de la atención dividida explica porque es más efectivo dibujar un diagrama
-  pieza por pieza mientras enseñas que presentar todo el gráfico de una sola vez.
+\begin{aside}{Fragmento a fragmento}
+  El efecto de la atención dividida explica por qué es más efectivo dibujar un diagrama
+  fragmento a fragmento mientras enseñas, en lugar de presentar todo el gráfico de una sola vez.
   Si las partes de un diagrama aparecen al mismo tiempo en que los gráficos son explicados,
-  ambos elementos serán correlacionados en la memoria del aprendiz.
-  Enfocarnos luego solo en una parte del diagrama es lo más parecido a activar la recuperación
+  el/la estudiante correlaciona ambos elementos en su memoria.
+  Así, al luego enfocarte en una parte del diagrama es más probable que tu estudiante active la recuperación
   de lo que fue dicho cuando esa parte fue dibujada.
 \end{aside}
 
 El efecto de la atención dividida \emph{no} significa
-que las/los estudiantes no deberían intentar conciliar múltiples flujos de información entrantes —después de todo, esto es lo que tienen que hacer en el mundo real~\cite{Atki2000}—.
+que los/las estudiantes no deberían intentar conciliar múltiples flujos de información entrantes —después de todo, esto es lo que tienen que hacer en el mundo real~\cite{Atki2000}—.
 En cambio, significa que la instrucción no debería solicitar a las personas
 que lo hagan mientras están incorporando habilidades por primera vez:
 el uso de múltiples fuentes  de información de manera simultánea debe tratarse como una tarea de aprendizaje separada.
 
-\begin{aside}{No todos los gráficos son creados iguales}
+\begin{aside}{No todos los gráficos son equivalentes}
   \cite{Sung2012} presenta un elegante estudio que distingue los gráficos \emph{seductores}\index{graphics!seductive}
   (los cuales son altamente interesantes pero no son directamente relevantes al objetivo de la enseñanza),
   los gráficos\emph{decorativos}\index{graphics!decorative}
@@ -80,18 +80,17 @@ el uso de múltiples fuentes  de información de manera simultánea debe tratars
   y por último
   los gráficos \emph{instructivos}\index{graphics!instructive}
   (los cuales sí son directamente relevantes al objetivo de la enseñanza).
-  Los estudiantes que recibieron cualquier tipo de gráfico obtuvieron calificaciones de satisfacción
-  del material más altas que aquellos que no obtuvieron gráficos,
-  pero en realidad solo las/los estudiantes que obtuvieron gráficos instructivos obtuvieron mejores resultados.
-
-
+  Los/las estudiantes que recibieron cualquier tipo de gráfico calificaron al material
+  con un mayor puntaje, pero en verdad solo quienes recibieron gráficos instructivos
+  obtuvieron mejores resultados.
+  
   Del mismo modo,~\cite{Stam2013,Stam2014} descubrió que
-  tener más información, en realidad puede disminuir el rendimiento.
-  Les mostraron a  niñas/os dibujos, dibujos y números, y simplemente números
-  para dos tareas.
-  Para algunos, tener imágenes o imágenes y números superó al tener solo números,
-  pero para otros, tener imágenes superó a las imágenes y números,
-  lo que superó solo tener números.
+  tener más información en realidad puede disminuir el rendimiento.
+  Les mostraron a niños/as: imágenes, imágenes más números, o simplemente números,
+  para que realicen dos tareas. 
+  Para algunos/as niños/as, recibir imágenes o bien imágenes más números fue mejor que tener únicamente números;
+  pero para otros/as, recibir imágenes superó a tener imágenes más números,
+  lo que superó a solo tener números.
 \end{aside}
 
 \seclbl{Carga cognitiva}{s:architecture-load}
@@ -101,49 +100,48 @@ En~\cite{Kirs2006}, Kirschner, Sweller y Clark escribieron:
 \begin{quote}
  
   Aunque los enfoques educativos no guiados o mínimamente guiados son muy    
-  populares e intuitivamente atractivos{\ldots}estos enfoques ignoran tanto
-  las estructuras que constituyen la arquitectura cognitiva humana como
-  la evidencia de estudios empíricos de los últimos cincuenta años que indican
-  sistemáticamente que la instrucción guiada mínimamente es menos eficaz y
-  menos eficiente que los enfoques educacionales que hacen un fuerte énfasis
-  en la orientación del proceso de aprendizaje del estudiante.
-  La ventaja de la orientación disminuye sólo cuando las/os estudiantes
+  populares e intuitivamente atractivos{\ldots}estos enfoques ignoran 
+  las estructuras que constituyen la arquitectura cognitiva humana así como
+  la evidencia de estudios empíricos de los últimos cincuenta años. Dichas evidencias
+  indican   sistemáticamente que la instrucción guiada mínimamente es menos eficaz y
+  menos eficiente que los enfoques educacionales con un fuerte énfasis
+  en la orientación del proceso de aprendizaje del/de la estudiante.
+  La ventaja de la orientación disminuye sólo cuando los/las estudiantes
   tienen un conocimiento previo suficientemente elevado para proporcionar una orientación ``interna''.
 \end{quote}
 
-Debajo de la jerga,
-los autores afirmaban que el hecho de que las/los estudiantes hagan sus propias preguntas,
+Más allá de la jerga,
+lo que estos autores afirmaban es que el hecho de que los/las estudiantes hagan sus propias preguntas,
 establezcan sus propias metas y
 encuentren su propio camino a través de un tema es menos efectivo que mostrarles
 cómo hacer las cosas paso a paso. El enfoque ``elige tu propia aventura'' se conoce como \gref{g:inquiry-based-learning}{aprendizaje basado en la indagación}
 y es intuitivamente atractivo: después de todo,
 ¿quién se \emph{opondría} a tener estudiantes que utilicen su propia iniciativa
 para resolver problemas del mundo real de forma realista?
-Sin embargo, pedir a las/los estudiantes que lo hagan en un nuevo dominio les sobrecarga
-al exigirles que dominen el contenido fáctico de un dominio y sus estrategias de resolución de problemas al mismo tiempo.
+Sin embargo, pedir a los/las estudiantes que lo hagan en un nuevo dominio es una sobrecarga,
+ya que les exige que dominen al mismo tiempo el contenido fáctico de un dominio y las estrategias de resolución de problemas.
 Más específicamente,
 \gref{g:cognitive-load}{la teoría de la carga cognitiva} propone que
-la gente tiene que lidiar con tres cosas cuando está aprendiendo:
+las personas tienen que lidiar con tres cosas cuando está aprendiendo:
 
 
 \begin{description}
 
-\item[\grefdex{g:intrinsic-load}{Carga Intrínseca}{cognitive load!intrinsic}]
-  es lo que la gente tiene que tener en cuenta para aprender el material nuevo.
+\item[\grefdex{g:intrinsic-load}{Carga intrínseca}{cognitive load!intrinsic}]
+  es lo que las personas tienen que tener en cuenta para aprender el material nuevo.
 
-\item[\grefdex{g:germane-load}{Carga Pertinente}{cognitive load!germane}]
+\item[\grefdex{g:germane-load}{Carga pertinente}{cognitive load!germane}]
   es el esfuerzo mental (deseable) requerido para vincular la nueva información con la antigua,
-  que es una de las cosas que distinguen el aprendizaje de la memorización.
+  que es una de las distinciones entre el aprendizaje y la memorización.
 
-
-\item[\grefdex{g:extraneous-load}{Carga Extrínseca}{cognitive load!extraneous}]
-es cualquier cosa que distraiga del aprendizaje.
+\item[\grefdex{g:extraneous-load}{Carga extrínseca}{cognitive load!extraneous}]
+es cualquier cuestión que distraiga del aprendizaje.
 
 \end{description}
 
 La teoría de la carga cognitiva sostiene que
-la gente tiene que dividir una cantidad fija de memoria de trabajo entre estas tres cosas.
-Nuestro objetivo como profesores es maximizar la memoria disponible para manejar la carga intrínseca,
+las personas tienen que dividir una cantidad fija de memoria de trabajo entre estas tres cosas.
+Nuestro objetivo como docentes es maximizar la memoria disponible para manejar la carga intrínseca,
 lo cual significa reducir la carga pertinente en cada paso y eliminar la carga extrínseca.
 
 
@@ -151,41 +149,40 @@ lo cual significa reducir la carga pertinente en cada paso y eliminar la carga e
 
 Un tipo de ejercicio que puede ser explicado en términos de carga cognitiva
 se utiliza a menudo en la enseñanza de idiomas.
-Supongamos que le pides a alguien que traduzca la frase,
-``¿Cómo está tu rodilla hoy?'' a lengua frisona(frisón).
+Supongamos que le pides a alguien que traduzca la frase
+``¿Cómo está tu rodilla hoy?'' de castellano a catalán.
 Para resolver el problema, necesitan recordar tanto el vocabulario
 como la gramática, que es una carga cognitiva doble.
-Si les pides que pongan ``hoe'', ``har'', ``is'', ``hjoed'' y ``knie'' en el orden correcto,
-por otro lado, les permites que se centren únicamente en el aprendizaje de la gramática.
-Si escribes estas palabras en cinco fuentes o colores diferentes,
-sin embargo, has aumentado la carga cognitiva externa, porque involuntariamente
+Si, en lugar de traducir desde cero, les pides que pongan ``com'', ``està'', ``el'', ``teu'', ``genoll'' y ``avui'' en el orden correcto,
+les permites que se centren únicamente en el aprendizaje de la gramática.
+Sin embargo, si escribes estas palabras en seis fuentes o colores diferentes,
+has aumentado la carga cognitiva extrínseca, porque involuntariamente
 (y posiblemente de manera inconsciente) invertirán algo de esfuerzo tratando de averiguar
-si las diferencias son significativas (\figref{f:architecture-frisian}).
+si las diferencias entre las palabras son significativas de acuerdo a sus colores (\figref{f:architecture-frisian}).
 
 \figimg{figures/frisian.png}{Construyendo una oración}{f:architecture-frisian}
 
-El equivalente de codificación de este
-se llama \gref{g:parsons-problem}{Problema de Parsons}\footnote{Nombrado debido a uno de sus creadores.}~\cite{Pars2006}.
+El equivalente de codificación de este ejemplo
+se llama \gref{g:parsons-problem}{problema de Parsons}\footnote{Nombrado así debido a uno de sus creadores.}~\cite{Pars2006}.
 
-Cuando se enseña a la gente a programar,
-puedes darles las líneas de código que necesitan para resolver un problema
-y pedirles que las pongan en el orden correcto.
-Esto les permite concentrarse en el flujo de control y las dependencias de datos
+Cuando enseñes a programar,
+puedes darles a tus estudiantes las líneas de código que necesitan para resolver un problema
+y pedirles que las ordenen en el orden correcto.
+Esto les permite concentrarse en el flujo de control y en las dependencias de datos,
 sin distraerse con la denominación de las variables o tratando de recordar qué funciones llamar.
-Múltiples estudios han demostrado que los problemas de Parsons les toma a los estudiantes menos tiempo resolverlo
-pero producen resultados educativos equivalentes~\cite{Eric2017}.
+Múltiples estudios han demostrado que los problemas de Parsons demandan menos tiempo de resolución pero producen resultados educativos equivalentes~\cite{Eric2017}.
 
 
 \subsection*{Ejemplos desvanecidos}
 
 Otro tipo de ejercicio que se puede explicar en términos de carga cognitiva
-es dar a las/los estudiantes una serie de ejemplos desvanecidos \grefdex{g:faded-example}{faded examples}{faded example}.
+es dar a tus estudiantes una serie de ejemplos desvanecidos \grefdex{g:faded-example}{faded examples}{faded example}.
 El primer ejemplo de una serie presenta un uso completo de una estrategia
 particular de resolución de problemas.
 El siguiente problema es del mismo tipo,
-pero tiene algunas lagunas que el estudiante debe llenar.
-Cada problema sucesivo le da al estudiante menos \gref{g:scaffolding}{scaffolding},
-hasta que se le pide que resuelva un problema completo desde cero.
+pero tiene algunas lagunas que tu estudiante debe llenar.
+Cada problema sucesivo da menos \gref{g:scaffolding}{scaffolding},
+hasta que se pide resolver un problema completo desde cero.
 Al enseñar álgebra en la escuela secundaria,
 por ejemplo,
 podríamos comenzar con esto:
@@ -204,7 +201,7 @@ podríamos comenzar con esto:
 \end{center}
 
 \noindent
-y luego pide a las/los estudiantes que resuelvan esto:
+y luego pedir que los/las estudiantes resuelvan esto:
 
 \begin{center}
 \begin{tabular}{rcl}
@@ -230,7 +227,7 @@ y esto:
 \end{center}
 
 \noindent
-y finalmente, esto:
+y, finalmente, esto:
 
 \begin{center}
 \begin{tabular}{rcl}
@@ -253,7 +250,7 @@ define total_length(list_of_words):
 
 \noindent
 
-y luego pídales que llenen los espacios en blanco en esto
+y luego pidiendo que llenen los espacios en blanco aquí
 (lo que centra su atención en las estructuras de control):
 
 
@@ -278,7 +275,7 @@ define join_all(list_of_words):
     return joined_words
 \end{minted}
 
-Finalmente, se pedirá a las/los estudiantes que escriban una función completa por su cuenta:
+Finalmente, los/las estudiantes tendrán que escribir una función completa por su cuenta:
 
 \begin{minted}{text}
 # make_acronym(["red", "green", "blue"]) => "RGB"
@@ -287,17 +284,17 @@ define make_acronym(list_of_words):
 \end{minted}
 
 Los ejemplos difusos funcionan porque
-presentan la estrategia de resolución de problemas pieza por pieza:
-en cada paso,
-las/los estudiantes tienen un nuevo problema que abordar,
-que es menos intimidante que una pantalla en blanco o una hoja de papel en blanco (\secref{s:classroom-practices}).
-También anima a las/los estudiantes a pensar en las similitudes y diferencias entre varios enfoques,
-lo que ayuda a crear los vínculos en sus modelos mentales que ayudan a la recuperación de la información.
+presentan la estrategia de resolución de problemas fragmento por fragmento.
+En cada paso,
+los/las estudiantes tienen un nuevo problema que abordar,
+lo cual es menos intimidante que una pantalla en blanco o una hoja de papel en blanco (\secref{s:classroom-practices}).
+También anima a que los/las estudiantes piensen en las similitudes y diferencias entre varios enfoques,
+lo que ayuda a crear los vínculos en sus modelos mentales y desde modo facilita la recuperación de la información.
 
 La clave para construir un buen ejemplo desvanecido es
 pensar en la estrategia de resolución de problemas que se pretende enseñar.
 Por ejemplo,
-los problemas de programación sobre todo utilizan el patrón de diseño del acumulador,
+los problemas de programación sobre todo utilizan el patrón de diseño acumulativo,
 en el que los resultados del procesamiento de elementos de una colección
 se agregan repetidamente a una sola variable de alguna manera para crear el resultado final.
 
@@ -305,34 +302,34 @@ se agregan repetidamente a una sola variable de alguna manera para crear el resu
 \begin{aside}{Aprendizaje cognitivo}
   Un modelo alternativo de aprendizaje e instrucción que también usa andamiaje y desvanecimiento
   es el \gref{g:cognitive-apprenticeship}{aprendizaje cognitivo},
-  que enfatiza la forma en que un maestro transmite habilidades y conocimientos a un aprendiz.
-  El maestro proporciona modelos de desempeño y resultados,
-  luego entrena a las/los principiantes explicando qué están haciendo y por qué~\cite{Coll1991,Casp2007}.
-  El aprendiz reflexiona sobre su propia resolución de problemas,
+  que enfatiza la forma en que un/a maestro/a transmite habilidades y conocimientos a un aprendiz.
+  El/la maestro/a proporciona modelos de desempeño y resultados,
+  luego entrena a las personas novatas explicando qué están haciendo y por qué~\cite{Coll1991,Casp2007}.
+  El/la aprendiz reflexiona sobre su propia resolución de problemas,
   por ejemplo, pensando en voz alta o criticando su propio trabajo,
   y finalmente explora problemas de su propia elección.
 
   Este modelo nos dice que
-  las/los profesores deben presentar varios ejemplos al explicar una nueva idea
-  para que las/los estudiantes puedan ver qué generalizar,
+  los/las docentes deben presentar varios ejemplos al explicar una nueva idea
+  para que los/las estudiantes puedan ver qué generalizar,
   y que deben variar la forma del problema para dejar en claro
-  cuáles son y cuáles no son características superficiales features\footnote{Por mucho tiempo,
+  cuáles son y cuáles no son características superficiales\footnote{Por mucho tiempo
      creí que la variable que contenía el valor que una función iba a devolver
-     \emph{tenía} que llamarse \texttt{resultado}
+     \emph{tenía} que llamarse \texttt{resultado},
      porque mi maestro siempre usaba ese nombre en los ejemplos.}.    
   Los problemas deben presentarse en contextos del mundo real,
-  y debemos fomentar la autoexplicación para ayudar a las/los estudiantes
+  y debemos fomentar la autoexplicación para ayudar a los/las estudiantes
   a organizarse y dar sentido a lo que se les acaba de enseñar
  (\secref{s:individual-strategies}).
 \end{aside}
 
 
-\subsection*{Subobjetivos etiquetados}
+\subsection*{Sub\-objetivos etiquetados}
  
-\grefdex{g:subgoal-labeling}{Labeling subgoals}{labeled subgoals} significa
+\grefdex{g:subgoal-labeling}{Etiquetar sub\-objetivos}{labeled subgoals} significa
 dar nombre a los pasos en una descripción paso a paso de un proceso de resolución de problemas.
-\cite{Marg2016,Morr2016} descubrieron que los estudiantes con subobjetivos etiquetados
-resolvían los problemas de Parsons mejor que las/los estudiantes sin estos,
+\cite{Marg2016,Morr2016} descubrieron que al etiquetar los sub\-objetivos, los/las estudiantes 
+resolvían mejor los problemas de Parsons,
 y se observa el mismo beneficio en otros dominios~\cite{Marg2012}.
 Volviendo al ejemplo de Python usado anteriormente,
 los objetivos secundarios para encontrar la longitud total de una lista de palabras o construir un acrónimo son:
@@ -340,21 +337,21 @@ los objetivos secundarios para encontrar la longitud total de una lista de palab
 \begin{enumerate}
 
 \item
-  Crea un valor vacío del tipo que se devolverá.
+  Crea un valor vacío del tipo a obtener.
 
 \item
-  Obtiene el valor que se agregará al resultado de la variable de ciclo.
+  A partir de la variable del bucle, obtén el valor que se agregará al resultado.
 
 \item
   Actualiza el resultado con ese valor.
 
 \end{enumerate}
 
-Etiquetar subobjetivos funciona porque agrupar los pasos relacionados en fragmentos con nombre(\secref{s:memory-seven-plus-or-minus})\index{chunking}
-ayuda a las/los estudiantes a distinguir lo que es genérico de lo que es específico del problema en cuestión.
-También les ayuda a construir un modelo mental de ese tipo de problema
-para que puedan resolver otros problemas de ese tipo
-y les da una oportunidad natural para la autoexplicación (\secref{s:individual-strategies}).
+Etiquetar sub\-objetivos funciona porque agrupar los pasos relacionados en fragmentos con nombre (\secref{s:memory-seven-plus-or-minus})\index{chunking}
+ayuda a tus estudiantes a distinguir lo que es genérico de lo que es específico del problema en cuestión.
+También les ayuda a construir un modelo mental de ese tipo de problema,
+de modo que luego pueden resolver otros problemas de ese tipo,
+y les da una oportunidad natural para la auto\-explicación (\secref{s:individual-strategies}).
 
 \subsection*{Manuales mínimos}
 
@@ -374,55 +371,55 @@ independientemente de la experiencia previa con computadoras~\cite{Lazo1993}.
 
 \begin{quote}
 
-  Nuestros diseños ``minimalistas'' buscaban aprovechar la iniciativa del usuario y el conocimiento previo,
+  Nuestros diseños ``minimalistas'' buscaban aprovechar la iniciativa de cada usuario/a y el conocimiento previo,
   en lugar de controlarlo mediante advertencias y pasos ordenados.
-  Enfatizó que los usuarios generalmente aportan mucha experiencia y conocimiento a este aprendizaje,
+  Se enfatizaba que los/las usuarios/as generalmente aportan mucha experiencia y conocimiento a este aprendizaje,
   por ejemplo,
   conocimiento sobre el dominio de la tarea,
-  y que dicho conocimiento podría ser un recurso para los diseñadores instruccionales.
+  y que dicho conocimiento podría ser un recurso para los/as diseñadores de instructivos.
   El minimalismo aprovechó los episodios de reconocimiento, diagnóstico y corrección de errores,
-  en lugar de intentar simplemente prevenirlos.
-  Enmarca la resolución de problemas y la corrección como oportunidades de aprendizaje en lugar de aberraciones.
+  en lugar de intentar simplemente prevenirlos. Es decir,
+  enmarcó la resolución de problemas y la corrección como oportunidades de aprendizaje en lugar de aberraciones.
 
 \end{quote}
 
 
 \seclbl{Otros modelos de aprendizaje}{s:architecture-theory}
 
-Los críticos de la teoría de la carga cognitiva a veces han argumentado que\index{cognitive load!criticism of}
-cualquier resultado puede justificarse a posteriori al etiquetar las cosas que perjudican el rendimiento como cargas extrañas
-y las que no lo hacen como intrínsecas o pertinentes.
+Quienes critican la teoría de la carga cognitiva a veces han argumentado que\index{cognitive load!criticism of}
+cualquier resultado puede justificarse \emph{a posteriori} al etiquetar como carga extrínseca a
+aquello que perjudica el rendimiento 
+y como carga intrínseca o pertinente a aquello que no lo perjudica..
 Sin embargo,
 la instrucción basada en la teoría de la carga cognitiva es innegablemente efectiva.
 Por ejemplo,
 \cite{Maso2016} rediseñó un curso de base de datos para eliminar la atención dividida y los efectos de redundancia
 y para proporcionar ejemplos prácticos y subobjetivos.
 El nuevo curso redujo la tasa de reprobación del examen en un 34\%
-y aumentó la satisfacción del estudiante.
-
+y aumentó la satisfacción de los/las estudiantes.
 
 Una década después de la publicación de~\cite{Kirs2006},
-un número creciente de personas cree que la teoría de la carga cognitiva y los enfoques basados en la investigación son compatibles
+un número creciente de personas cree que la teoría de la carga cognitiva y los enfoques basados ​​en la investigación son compatibles
 si se ven de la manera correcta.
 \cite{Kaly2015} sostiene que la teoría de la carga cognitiva es básicamente una microgestión del aprendizaje
-dentro de un contexto más amplio que considera cosas como la motivación,
+dentro de un contexto más amplio que considera cuestiones como la motivación,
 mientras que~\cite{Kirs2018} extiende la teoría de la carga cognitiva para incluir aspectos colaborativos del aprendizaje.
 Al igual que con~\cite{Mark2018} (discutido en \secref{s:individual-strategies}),
-las perspectivas de los investigadores pueden diferir,
+las perspectivas de los/las investigadores/as pueden diferir,
 pero la implementación práctica de sus teorías a menudo termina siendo la misma.
 
 Uno de los desafíos en la investigación educativa es que
 lo que queremos decir con ``aprendizaje'' resulta complicado
 una vez que se mira más allá del aula occidental estandarizada.
 Dos perspectivas específicas de la \gref{g:educational-psychology}{psicología educativa} han influido en este libro.
-El que hemos utilizado hasta ahora es el \gref{g:cognitivism}{cognitivismo},
-que se centra en cosas como el reconocimiento de patrones, la formación de la memoria y el recuerdo.
+La que hemos utilizado hasta ahora es el \gref{g:cognitivism}{cognitivismo},
+que se centra en conceptos como el reconocimiento de patrones, la formación de la memoria y el recuerdo.
 Es bueno para responder preguntas de bajo nivel,
 pero generalmente ignora cuestiones más importantes como,
 ``¿Qué queremos decir con 'aprendizaje'?'' y
-``¿Quién decide?''
-El otro es el \gref{g:situated-learning}{aprendizaje situado},
-que se centra en llevar a las personas a una comunidad
+``¿Quién tiene poder de decisión?''
+La segunda perspectiva utilizada es el \gref{g:situated-learning}{aprendizaje situado},
+que se centra en integrar a las personas en una comunidad
 y reconoce que
 la enseñanza y el aprendizaje siempre están arraigados en quiénes somos y quiénes aspiramos a ser.
 Lo discutiremos con más detalle en el \chapref{s:community}.
@@ -431,56 +428,56 @@ Lo discutiremos con más detalle en el \chapref{s:community}.
 El sitio web de \hreffoot{http://www.learning-theories.com/}{Learning Theories, teorías de aprendizaje en inglés}
 y~\cite{Wibu2016}
 tienen buenos resúmenes de estas y otras perspectivas.
-Además del cognitivismo, los que se encuentran con mayor frecuencia incluyen el \gref{g:behaviorism}{conductismo}
+Además del cognitivismo, las que se encuentran con mayor frecuencia incluyen el \gref{g:behaviorism}{conductismo}
 (que trata la educación como un condicionamiento de estímulo/respuesta),
 el \gref{g:constructivism}{constructivismo}
-(que considera el aprendizaje como un proceso activo durante el cual las/los estudiantes construyen conocimiento por sí mismos)
+(que considera al aprendizaje como un proceso activo durante el cual los/las estudiantes construyen conocimiento por sí mismos)
 y el \gref{g:connectivism}{conectivismo}.
 (que sostiene que el conocimiento se distribuye,
 que el aprendizaje es el proceso de navegar, crecer y podar conexiones,
-y que enfatiza los aspectos sociales del aprendizaje que Internet hace posible).
+y que enfatiza los aspectos sociales del aprendizaje que internet hace posible).
 Estas perspectivas pueden ayudarnos a organizar nuestros pensamientos,
-pero en la práctica,
-siempre tenemos que probar nuevos métodos en la clase,
+pero en la práctica
+siempre tenemos que probar nuevos métodos en clase,
 con estudiantes reales,
 para descubrir qué tan bien equilibran las muchas fuerzas en juego.
 
 \seclbl{Ejercicios}{s:architecture-exercises}
 
-\exercise{Crear un ejemplo desvanecido}{pares}{30'}
+\exercise{Crear un ejemplo desvanecido}{parejas}{30'}
 
-Es muy común que los programas cuenten cuántas cosas caen en diferentes categorías:
+Es muy común que en los programas se cuenten cuántas cosas caen en diferentes categorías:
 por ejemplo,
 cuántas veces aparecen colores diferentes en una imagen
 o cuántas veces aparecen palabras diferentes en un párrafo de texto.
 
 \begin{enumerate}
 \item
-    Crea un ejemplo breve (no más de 10 líneas de código) que muestre a las personas cómo hacer esto,
-    y luego crea un segundo ejemplo que resuelva un problema similar de una manera similar
-    pero que tenga un par de espacios en blanco para que las/los estudiantes los completen.
-    ¿Decides qué desvanecer?
+    Crea un ejemplo breve (no más de 10 líneas de código) que muestre a las personas cómo hacer esto.
+    Luego, crea un segundo ejemplo que resuelva un problema similar de una manera similar,
+    pero que tenga un par de espacios en blanco para que los/las estudiantes los completen.
+    ¿Cómo decides qué desvanecer?
     ¿Cuál sería el siguiente ejemplo de la serie?
 
 \item
-    Define la audiencia de sus ejemplos.
+    Define el público de tus ejemplos.
     Por ejemplo,
-    ¿son  principiantes que solo conocen algunos conceptos básicos de programación?
-    ¿O son estudiantes tienen alguna experiencia en programación?
+    ¿son  personas principiantes que solo conocen algunos conceptos básicos de programación?
+    ¿O son estudiantes con alguna experiencia en programación?
 
 \item
     Muestra tu ejemplo a tu pareja,
-    pero no le digas para qué nivel crees que es.
-    Una vez que hayan llenado los espacios en blanco,
-    pídeles que adivinen el nivel deseado.
+    pero \emph{no} le digas para qué nivel crees que es.
+    Una vez que tu pareja haya llenado los espacios en blanco,
+    pídele que adivine el nivel de estudiante previsto.
 
 \end{enumerate}
 
-Si hay personas entre los aprendices que no programan en absoluto,
+Si entre tus estudiantes hay personas que no programan en absoluto,
 intenta ubicarlos en diferentes grupos
 y pídeles que hagan el papel de aprendices para esos grupos.
 Alternativamente,
-elije un dominio de problema diferente y desarrolla un ejemplo difuso para él.
+elige un dominio de problema diferente con el que desarrollar tu ejemplo desvanecido.
 
 
 \exercise{Clasificación de carga}{grupos pequeños}{15'}
@@ -488,33 +485,33 @@ elije un dominio de problema diferente y desarrolla un ejemplo difuso para él.
 \begin{enumerate}
 
 \item
-  Elige una lección corta que un miembro de tu grupo haya enseñado o tomado recientemente.
+  Elige una lección corta que alguna persona de tu grupo haya enseñado o tomado recientemente.
 
 \item
-  Haz una lista en forma de puntos de las ideas, instrucciones y explicaciones que contiene.
+  Haz un listado con viñetas de las ideas, instrucciones y explicaciones que contiene la lección.
 
 \item
-  Clasifica cada uno como intrínseco, pertinente o extraño.
-  ¿En qué partes estaban todos de acuerdo?
-  ¿Dónde estuvo en desacuerdo y por qué?
+  Clasifica cada elemento de tu listado como carga intrínseca, pertinente o extrínseca.
+  ¿En qué ítems todas las personas del grupo estuvieron de acuerdo?
+  ¿En cuáles estuvieron en desacuerdo y por qué?
 
 \end{enumerate}
 
-(El ejercicio ``Cómo darse cuenta de su punto ciego'' en \secref{s:memory-exercises}
-le dará una idea de cuán detallada debe ser su lista de formularios de puntos).
+(El ejercicio ``Notar tus puntos ciegos'' en \secref{s:memory-exercises}
+te dará una idea de cuán detallado debe ser tu listado de ítems).
 
 
-\exercise{Crear un problema de Parsons}{parejas}{20'}
+\exercise{Crear un problema de Parsons}{en parejas}{20'}
 
 Escribe cinco o seis líneas de código que hagan algo útil,
-mezclalas y pídele a tu compañero que las ponga en orden.
-Si estás utilizando un lenguaje basado en identación como Python,
+mézclalas y pídele a tu pareja que las ponga en orden.
+Si estás utilizando un lenguaje basado en indentación como Python,
 no utilices sangría en ninguna de las líneas;
 si estás utilizando un lenguaje de llaves como Java,
 no incluyas ninguna de las llaves.
-(Si tu grupo incluye personas que no son programadores,
+(Si tu grupo incluye personas que no programan,
 usa un dominio de problema diferente,
-como hacer budín/pan de plátano).
+como hacer pan de banana).
 
 
 \exercise{Manuales mínimos}{individual}{20'}
@@ -522,7 +519,7 @@ como hacer budín/pan de plátano).
 Escribe una guía de una página para hacer algo que tus estudiantes puedan encontrar en una de tus clases,
 como centrar el texto horizontalmente
 o imprimir un número con un cierto número de dígitos después del punto decimal.
-Intentá enumerar al menos tres o cuatro resultados incorrectos que el estudiante pueda ver
+Intenta enumerar al menos tres o cuatro resultados incorrectos que tu estudiante pueda obtener
 e incluye una explicación de una o dos líneas
 de por qué ocurre cada uno y cómo corregirlo.
 
@@ -531,21 +528,21 @@ de por qué ocurre cada uno y cómo corregirlo.
 
 Elige un problema de codificación que puedas resolver en dos o tres minutos
 y piensa en voz alta mientras lo resuelves,
-al mismo tiempo tu compañero te hace preguntas sobre lo que estás haciendo y por qué.
+al mismo tiempo tu pareja te hace preguntas sobre lo que estás haciendo y por qué.
 No solo explica lo que estás haciendo,
 sino también por qué lo estás haciendo,
 cómo sabes que es lo correcto y qué alternativas has considerado pero descartado.
 Cuando hayas terminado,
-intercambia roles con tu compañero y repite el ejercicio.
+intercambia roles con tu pareja y repite el ejercicio.
 
 
 \exercise{Ejemplos resueltos}{parejas}{15'}
 
 Ver ejemplos resueltos ayuda a las personas a aprender a programar más rápido que simplemente escribiendo mucho código~\cite{Skud2014},
-y deconstruir/desagregar el código rastreándolo o depurándolo también aumenta el aprendizaje~\cite{Grif2016}.
+y deconstruir el código rastreándolo o depurándolo también aumenta el aprendizaje~\cite{Grif2016}.
 Trabajando en parejas, revisa un fragmento de código de 10 a 15 líneas
 y explica qué hace cada declaración y por qué es necesaria.
-¿Cuánto tiempo te tardas?
+¿Cuánto tiempo demoras?
 ¿Cuántas cosas crees que necesitas explicar por línea de código?
 
 \exercise{Gráficos críticos}{individual}{30'}
@@ -559,30 +556,30 @@ y explica qué hace cada declaración y por qué es necesaria.
   para que se destaquen del material menos crítico.
 
 \item[Contigüidad espacial:]
-  coloca los subtítulos lo más cerca posible de los gráficos para compensar el costo de cambiar entre los dos.
+  coloca los subtítulos lo más cerca posible de los gráficos para compensar el costo de cambiar entre la imagen y el texto.
 
 \item[Contigüidad temporal:]
-  Presenta narraciones y gráficos hablados tan seguidos en el tiempo como sea práctico.
+  Presenta narraciones habladas y gráficos tan seguidos en el tiempo como sea práctico.
   (Presentar ambos a la vez es mejor que presentarlos uno tras otro).
 
 \item[Segmentación:]
   Cuando presentes una secuencia larga de material o
-  cuando los estudiantes no tengan experiencia con el tema,
+  cuando tus estudiantes no tengan experiencia en el tema,
   divide la presentación en segmentos cortos y deja que los estudiantes controlen la rapidez con que avanzan al siguiente.
 
 \item[Pre-entrenamiento:]
-  Si los estudiantes no conocen los conceptos y la terminología principales utilizados en tu presentación,
+  Si tus estudiantes no conocen los conceptos y la terminología principales que utilizas en la presentación,
   enseña solo esos conceptos y términos de antemano.
 
 \item[Modalidad:]
-las personas aprenden mejor de las imágenes más la narración que de las imágenes más el texto,
-a menos que no sean hablantes nativos o haya palabras o símbolos técnicos.
+las personas aprenden mejor de las imágenes con narración que de las imágenes con texto,
+a menos que no sean hablantes nativas del idioma de la lección o que haya palabras o símbolos técnicos.
 
 \end{description}
 
 Elige un video de una lección o charla en línea que utilice diapositivas u otras presentaciones estáticas
-y califique sus gráficos como ``deficientes'', ``promedio'' o ``buenos'' de acuerdo con estos seis criterios.
+y califica sus gráficos como ``deficientes'', ``promedio'' o ``buenos'' de acuerdo con estos seis criterios.
 
 \section*{Revisión}
 
-\figpdfhere{figures/conceptmap-cognitive-load.pdf}{Concepto: Carga congnitiva}{f:architecture-cognitive-load}
+\figpdfhere{figures/conceptmap-cognitive-load.pdf}{Conceptos: carga cognitiva}{f:architecture-cognitive-load}

--- a/es/architecture.tex
+++ b/es/architecture.tex
@@ -103,7 +103,7 @@ En~\cite{Kirs2006}, Kirschner, Sweller y Clark escribieron:
   populares e intuitivamente atractivos{\ldots}estos enfoques ignoran 
   las estructuras que constituyen la arquitectura cognitiva humana así como
   la evidencia de estudios empíricos de los últimos cincuenta años. Dichas evidencias
-  indican   sistemáticamente que la instrucción guiada mínimamente es menos eficaz y
+  indican sistemáticamente que la instrucción guiada mínimamente es menos eficaz y
   menos eficiente que los enfoques educacionales con un fuerte énfasis
   en la orientación del proceso de aprendizaje del/de la estudiante.
   La ventaja de la orientación disminuye sólo cuando los/las estudiantes

--- a/es/architecture.tex
+++ b/es/architecture.tex
@@ -302,7 +302,7 @@ se agregan repetidamente a una sola variable de alguna manera para crear el resu
 \begin{aside}{Aprendizaje cognitivo}
   Un modelo alternativo de aprendizaje e instrucción que también usa andamiaje y desvanecimiento
   es el \gref{g:cognitive-apprenticeship}{aprendizaje cognitivo},
-  que enfatiza la forma en que un/a maestro/a transmite habilidades y conocimientos a un aprendiz.
+  que enfatiza la forma en que un/a docente transmite habilidades y conocimientos a un/a aprendiz.
   El/la maestro/a proporciona modelos de desempeño y resultados,
   luego entrena a las personas novatas explicando qué están haciendo y por qué~\cite{Coll1991,Casp2007}.
   El/la aprendiz reflexiona sobre su propia resolución de problemas,

--- a/es/architecture.tex
+++ b/es/architecture.tex
@@ -582,4 +582,4 @@ y califica sus gráficos como ``deficientes'', ``promedio'' o ``buenos'' de acue
 
 \section*{Revisión}
 
-\figpdfhere{figures/conceptmap-cognitive-load.pdf}{Conceptos: carga cognitiva}{f:architecture-cognitive-load}
+\figpdfhere{figures/conceptmap-cognitive-load.pdf}{Conceptos: Carga cognitiva}{f:architecture-cognitive-load}


### PR DESCRIPTION
- Revisión general, quizás puede contar como la 2da revisión que no tenía.
- Revisión de lenguaje no sexista; estaba mayormente al revés el orden de femenino/masculino.
- Piece by piece: traduzco fragmento a fragmento; por consistencia con capítulos anteriores en donde se habla de los "fragmentos" de los mapas conceptuales.

- @yabellini Revisar si se entiende el apartado {No todos los gráficos son equivalentes}, cambié título y varias cosas de la traducción. En particular le cambié el sentido a:

_"Learners who received any kind of graphic gave material higher satisfaction ratings than those who didn’t get graphics, but only learners who got instructive graphics actually performed better.

Ahora es:

_"Los/las estudiantes que recibieron cualquier tipo de gráfico calificaron al material
  con un mayor puntaje, pero en verdad solo quienes recibieron gráficos instructivos
  obtuvieron mejores resultados."_

- Cambié un poco el sentido de la traducción del ejercicio de Python en \subsection*{Sub\-objetivos etiquetados}

- El ejemplo de la lengua frisona es medio inentendible en castellano --ni siquiera sabía que existe esa lengua y además las palabras no son parecidas, el/la lectora tiene que saber inglés para entender que knie es parecido a knee. Issue: https://github.com/gvwilson/teachtogether.tech/issues/305