### PR TITLE
Process.tex 2nd revision and general revision [es]

### DIFF
--- a/es/process.tex
+++ b/es/process.tex
@@ -34,7 +34,7 @@ cuando pasan las pruebas, dejas de programar.
 Finalmente,
 esto reduce el riesgo de sesgo de confirmación:
 una persona que aún no ha escrito un fragmento de software
-será más objetiva que alguien que acaba de dedicar varias horas al trabajo duro y realmente realmente quiere terminar.
+será más objetiva que alguien que acaba de dedicar varias horas al trabajo duro y realmente quiere terminar.
  
 Un método similar denominado \gref{g:backward-design}{reingeniería} funciona muy bien para el diseño de lecciones.
 Este método fue desarrollado en forma independiente en ~\cite{Wigg2005,Bigg2011,Fink2013} y está resumido en~\cite{McTi2013}

--- a/es/process.tex
+++ b/es/process.tex
@@ -43,7 +43,7 @@ En forma simplificada, sus pasos son:
 \begin{enumerate}
  
 \item
-Crea o recicla estudiantes tipo (concepto discutido en la siguiente sección)
+Crea o recicla personas tipo (concepto discutido en la siguiente sección)
 para imaginar a quiénes estás intentando ayudar y qué les atraerá.
 
  \item
@@ -118,16 +118,16 @@ Sin embargo,
 las notas que dejamos atrás deben presentar las tareas desarrolladas en el orden descripto anteriormente, para que quien tenga que usar o mantener la lección pueda seguir nuestros razonamientos
 ~\cite{Parn1986}.
  
-\seclbl{Estudiantes tipo}{s:process-personas}
+\seclbl{Personas tipo}{s:process-personas}
  
 El primer paso en el proceso de diseño inverso es averiguar quién es tu audiencia.
 Una manera para hacer esto es escribir dos o tres
-\grefdex{g:learner-persona}{learner personas}{estudiante tipo}
+\grefdex{g:learner-persona}{learner personas}{personas tipo}
 como los de \secref{s:intro-audience}.
 Esta técnica es tomada de diseñadores de experiencia de usuario,
 quienes crean perfiles breves de usuarios típicos
 para ayudarles a pensar en su audiencia.
-Una/un estudiante tipo consiste en:
+Una persona tipo consiste en:
  
 \begin{enumerate}
  
@@ -147,7 +147,7 @@ cualquier necesidad especial que tengan.
 \end{enumerate}
  Las personas en \secref{s:intro-audience} tienen los cuatro puntos listados anteriormente,
 junto con un breve resumen de cómo este libro les ayudará.
-Una/un estudiante tipo para un grupo de voluntarios que realiza talleres de Python los fines de semana sería:
+Una persona tipo para un grupo de voluntarios que realiza talleres de Python los fines de semana sería:
  
 \begin{enumerate}
  
@@ -463,12 +463,12 @@ diseñadas para estudiantes en niveles muy diferentes.
  
 \seclbl{Ejercicios}{s:process-exercises}
  
-\exercise{Crear estudiantes tipo}{grupos pequeños}{30'}
+\exercise{Crear personas tipo}{grupos pequeños}{30'}
  
 Trabajando en grupos pequeños,
 crea un tipo de 4 puntos que describa a una/uno de sus estudiantes estándar.
  
-\exercise{Clasificar Objetivos de Aprendizaje}{pares}{10'}
+\exercise{Clasificar objetivos de aprendizaje}{parejas}{10'}
  
 Mira el ejemplo de objetivos de aprendizaje
 para un curso introductorio sobre HTML y CSS
@@ -477,7 +477,7 @@ y clasifica cada uno de acuerdo a la Taxonomía de Bloom.
 Compara tus respuestas con las de tu compañera/o.
 ¿Dónde estuvieron de acuerdo y en desacuerdo?
  
-\exercise{Escribir Objetivos de Aprendizaje}{pares}{20'}
+\exercise{Escribir objetivos de aprendizaje}{parejas}{20'}
  
 Escribe uno o más objetivos de aprendizaje
 para algo que actualmente enseñas o planeas enseñar
@@ -487,7 +487,7 @@ critica y mejora los objetivos.
 ¿Cada uno tiene un verbo verificable y establece claramente
 los criterios  para un desempeño aceptable?
  
-\exercise{Escribir más Objetivos de Aprendizaje}{pares}{20'}
+\exercise{Escribir más Objetivos de Aprendizaje}{parejas}{20'}
  
 Escribe uno o más objetivos de aprendizaje
 para algo que actualmente enseñas o planeas enseñar
@@ -495,7 +495,7 @@ utilizando la Taxonomía de Fink.
 Trabajando en pareja,
 critica y mejora los objetivos.
  
-\exercise{Ayúdame a hacerlo sola/o}{grupos pequeños }{15'}
+\exercise{Ayúdame a hacerlo sola/o}{grupos pequeños}{15'}
  
 El teórico de la educación Lev Vygotsky introdujo la noción de una
 \gref{g:zpd}{Zona de Desarrollo Proximal} (ZPD por sus siglas en inglés),
@@ -505,7 +505,7 @@ Estos son los problemas que resultan más fructíferos abordar a continuación,
 ya que están fuera de tu alcance pero son alcanzables.
  
 Trabajando en grupos pequeños,
-escoge una/un estudiante tipo que hayas desarrollado
+escoge una persona tipo que hayas desarrollado
 y describe dos o tres problemas que se encuentran en la ZPD de esa/ese estudiante.
  
 \exercise{Construyendo lecciones, restando complejidad}{individual}{20'}
@@ -569,7 +569,7 @@ y luego hacer, del inglés \textbf{M}ake, algo similar desde cero.
 Elige algo que hayas enseñado o te hayan enseñado recientemente
 y bosqueja una breve lección que siga los siguientes cinco pasos.
  
-\exercise{Concreto-Figurativo-Abstracto}{pares}{15'}
+\exercise{Concreto-Figurativo-Abstracto}{parejas}{15'}
 \index{CRA (lesson pattern)}
 \index{lesson pattern!CRA}
  

--- a/es/process.tex
+++ b/es/process.tex
@@ -629,4 +629,4 @@ suficientes para convencerte de usar un sitio para compartir lecciones. Si no fu
  
 \section*{Revisión}
  
-\figpdfhere{figures/conceptmap-personas.pdf}{Concepto: personas tipo}{f:process-personas}
+\figpdfhere{figures/conceptmap-personas.pdf}{Concepto: Personas tipo}{f:process-personas}

--- a/es/process.tex
+++ b/es/process.tex
@@ -20,7 +20,7 @@ para crear un examen final
 y te prometes que la próxima vez serás más organizado/a.
 \end{enumerate}
 
-Un método más efectivo es similar en esencia a una práctica de programación llamada \gref{g:test-driven-development}{desarrollo-impulsado-por pruebas}.
+Un método más efectivo es similar en esencia a una práctica de programación llamada \gref{g:test-driven-development}{desarrollo-impulsado-por pruebas} (\emph{Test Driver Development (TDD) en inglés}).
 Los/las programadores/as que usan desarrollo impulsado por pruebas no escriben software
 y luego prueban que funcione correctamente.
 En su lugar,

--- a/es/process.tex
+++ b/es/process.tex
@@ -412,7 +412,7 @@ Esta ecuación depende de cuatro factores:
   Una razón para usar el diseño inverso
   es captar decisiones sobre por qué cada curso es como es.
  
-\item[Qué tan fácil es para los colaboradores ayudar]
+\item[Qué tan fácil es para los/las colaboradores ayudar]
   Los/las docentes suelen compartir material enviándose por correo archivos de PowerPoint o dejándolos en una unidad compartida.
   Herramientas de escritura colaborativa como \hreffoot{http://docs.google.com}{\emph{Google Docs}} y wikis
   son una gran mejora,

--- a/es/process.tex
+++ b/es/process.tex
@@ -30,7 +30,7 @@ luego escriben suficiente software nuevo para que esas pruebas pasen.
 Este método de programación funciona porque escribir pruebas obliga a
 tenér más precisión acerca de lo que están intentando lograr y cómo se ve ``finalizado''.
 El desarrollo impulsado por pruebas también evita el pulido sin fin:
-cuando pasan las pruebas, dejas de codificar.
+cuando pasan las pruebas, dejas de programar.
 Finalmente,
 esto reduce el riesgo de sesgo de confirmación:
 una persona que aún no ha escrito un fragmento de software

--- a/es/process.tex
+++ b/es/process.tex
@@ -347,7 +347,7 @@ pero a diferencia de las de Bloom ellas son complementarias y no jerárquicas:
   \emph{(usar, resolver, calcular, crear)}
  
 \item[Integración:]
-  conectar ideas, experiencias de aprendizaje y vida real
+  conectar ideas, experiencias de aprendizaje y vida real.
   \emph{(conectar, relatar, comparar)}
  
 \item[Dimensión humana:]

--- a/es/process.tex
+++ b/es/process.tex
@@ -339,7 +339,7 @@ pero a diferencia de las de Bloom ellas son complementarias y no jerárquicas:
 \begin{description}
  
 \item[Conocimiento fundamental:]
-  Comprender y recordar información e ideas.
+  comprender y recordar información e ideas.
   \emph{(recordar, comprender, identificar)}
  
 \item[Aplicación:]

--- a/es/process.tex
+++ b/es/process.tex
@@ -121,7 +121,7 @@ las notas que elaboremos deben presentar las tareas desarrolladas en el orden de
  
 El primer paso en el proceso de diseño inverso es averiguar quién es tu público.
 Una manera para hacer esto es escribir dos o tres
-\grefdex{g:learner-persona}{learner personas}{personas tipo}
+\grefdex{g:learner-persona}{personas tipo}
 como los de la \secref{s:intro-audience}.
 Esta técnica es tomada de diseñadores/as de experiencia de usuario/a,
 quienes crean perfiles breves de usuarios/as típicos/as

--- a/es/process.tex
+++ b/es/process.tex
@@ -359,7 +359,7 @@ pero a diferencia de las de Bloom ellas son complementarias y no jerárquicas:
   \emph{(emocionarse, estar preparado/a para, valorar)}
  
 \item[Aprendiendo a aprender:]
-  Convertirse en mejor estudiante.
+  convertirse en mejor estudiante.
   \emph{(identificar la fuente de información para, enmarcar preguntas útiles sobre)}
  
 \end{description}

--- a/es/process.tex
+++ b/es/process.tex
@@ -10,101 +10,100 @@ Alguien te pide que enseñes algo que sabes muy poco o que no has pensado en añ
 Empiezas escribiendo diapositivas para explicar lo que sabes sobre el tema.
 
  \item
-Después de 2 o 3 semanas,
-preparas una tarea basada en lo que has enseñado hasta ahora
+Después de dos o tres semanas,
+preparas una tarea basada en lo que has enseñado hasta ahora.
  \item
-Repites el paso 3 varias veces.
+Repites el tercer paso varias veces.
  \item
 Permaneces sin dormir hasta altas horas de la mañana
 para crear un examen final
-y te prometes que serás más organizada/o la próxima vez.
+y te prometes que la próxima vez serás más organizado/a.
 \end{enumerate}
 
 Un método más efectivo es similar en esencia a una práctica de programación llamada \gref{g:test-driven-development}{desarrollo-impulsado-por pruebas}(TDD por sus siglas en inglés).
-Las programadoras y los programadores que usan TDD no escriben software
-y luego testean/prueban que esté funcionando correctamente.
+Los/las programadores/as que usan TDD no escriben software
+y luego prueban que funcione correctamente.
 En su lugar,
 escriben la prueba primero,
 luego escriben suficiente software nuevo para que esas pruebas pasen.
  
-TDD funciona porque escribir pruebas obliga a quienes programan a ser más precisas/os acerca de lo que están intentando lograr y cómo se ve ``hecho''.
-TDD también evita el pulido sin fin:
+El TDD funciona porque escribir pruebas obliga a quienes programan a
+tenér más precisión acerca de lo que están intentando lograr y cómo se ve ``finalizado''.
+El TDD también evita el pulido sin fin:
 cuando pasan las pruebas, dejas de codificar.
 Finalmente,
 esto reduce el riesgo de sesgo de confirmación:
-alguien que aún no ha escrito un fragmento de software
-será más objetivo que alguien que acaba de dedicar varias horas al trabajo duro
-y realmente, realmente quiere terminar.
+una persona que aún no ha escrito un fragmento de software
+será más objetiva que alguien que acaba de dedicar varias horas al trabajo duro y realmente realmente quiere terminar.
  
-Un método similar denominado \gref{g:backward-design}{Reingeniería} funciona muy bien para el diseño de lecciones.
+Un método similar denominado \gref{g:backward-design}{reingeniería} funciona muy bien para el diseño de lecciones.
 Este método fue desarrollado en forma independiente en ~\cite{Wigg2005,Bigg2011,Fink2013} y está resumido en~\cite{McTi2013}
 En forma simplificada, sus pasos son:
  
 \begin{enumerate}
  
 \item
-Crear o reciclar estudiante tipo (discutido en la siguiente sección)
-para imaginar a quién estás intentando ayudar y qué les atraerá.
+Crea o recicla estudiantes tipo (concepto discutido en la siguiente sección)
+para imaginar a quiénes estás intentando ayudar y qué les atraerá.
 
  \item
-Haz una lluvia de ideas para tener una idea aproximada de lo que quieres cubrir,
+Haz un torbellino de ideas para tener una idea aproximada de lo que quieres cubrir,
 cómo lo vas a hacer,
 qué problemas o conceptos erróneos esperas encontrar,
-qué \emph{no} no se va a incluir,
-y etc.
+qué \emph{no} no se va a incluir, etcétera.
 Dibujar mapas conceptuales puede ayudar mucho en esta etapa (\secref{s:memory-concept-maps}).\index{concept map}
  
 \item
 Crea una evaluación sumativa (\secref{s:models-formative-assessment})\index{summative assessment}
 para definir tu objetivo general.
-Esto puede ser el examen final para un curso
-o el proyecto final para un taller de un día;
-independientemente de su forma o tamaño,
-muestra lo lejos que esperas llegar
+Dicha evaluación puede ser el examen final para un curso
+o el proyecto final para un taller de un día.
+Independientemente de su forma o extensión,
+la evaluación sumativa te mostrará lo lejos que esperas llegar
 más claramente que una lista puntual de objetivos.
  
 \item
-Crea evaluaciones formativas\index{formative assessment}
-eso le dará a las personas una oportunidad para practicar las cosas que están aprendiendo.
-Estas también te dirán a ti (y a las personas) si están progresando
+Crea evaluaciones formativas\index{formative assessment},
+lo cual le dará a tus estudiantes una oportunidad para practicar lo que están aprendiendo.
+Las evaluaciones formativas también te dirán a ti (y a tus estudiantes) si están progresando
 y dónde deben centrar su atención.
-El mejor camino para hacer esto es detallar los conocimientos y las habilidades
-utilizadas en la evaluación sumativa que desarrollaste en el paso anterior y
-luego crear al menos una evaluación sumativa para cada uno.
+El mejor camino para hacer esto es listar los conocimientos y las habilidades
+involucradas en la evaluación sumativa que desarrollaste en el paso anterior: luego, deberás crear una evaluación formativa para cada ítem.
  
 \item
 Ordena las evaluaciones formativas para crear un esquema del curso
 en función de su complejidad,
 sus dependencias,
-y cuán bien los temas motivarán a tus aprendices (\secref{s:motivation-authentic}).
+y cuán bien los temas motivarán a tus estudiantes (\secref{s:motivation-authentic}).
  
 \item
-Escribe material para conseguir que los/las alumnos/as pasen de una evaluación formativa a la siguiente.
-Cada hora de instrucción debe constar de tres a cinco episodios.
+Escribe material para conseguir que tus estudiantes pasen de una evaluación formativa a la siguiente.
+Cada hora de instrucción debe constar de tres a cinco de estos episodios.
  
 \item
 Escribe una descripción resumida del curso
-para ayudar a tu audiencia objetivo a encontrarlo
-y averiguar si es adecuado para ella.
+para ayudar a que tu público objetivo lo encuentre
+y averigue si es el curso adecuado.
  \end{enumerate}
  
 Este método ayuda a mantener la enseñanza enfocada en sus objetivos.
-También asegura que las/los estudiantes no se enfrenten a nada para lo que no están preparadas/os al final del curso.
+También asegura que tus estudiantes no se enfrenten al final del curso
+a nada para lo que no tengan preparación.
  
-\begin{aside}{Incentivos Perversos}
+\begin{aside}{Incentivos perversos}
 La reingeniería \emph{no} es lo mismo que gref{g:teaching-to-the-test}{enseñar para el examen}.
 Cuando se usa la reingeniería,
-el conjunto de docentes establece objetivos para ayudar en el diseño de las lecciones;
-es posible que ellas/ellos nunca den el examen final que escribieron.
+los/las docentes establecen objetivos para ayudar en el diseño de sus lecciones:
+es posible nunca den el examen final que preparan durante este proceso.
 En muchos sistemas escolares,
 por otro lado,
-una autoridad externa define los criterios de evaluación para todas/todos las/los estudiantes,
+una autoridad externa define los criterios de evaluación para todos/as los/las estudiantes,
 independientemente de sus situaciones individuales.
-Los resultados de esas evaluaciones sumativas afectan directamente el salario y promoción de las y los profesores,
-lo que significa que estos tienen un incentivo para enfocarse en que las/los estudiantes pasen las pruebas en lugar de ayudarles a aprender.
+Los resultados de esas evaluaciones sumativas afectan directamente los salarios y las promociones de los/las docentes,
+lo que significa que el plantel docente tienen un incentivo para enfocarse en que sus estudiantes pasen las pruebas, y no en ayudarles a aprender.
  
-\cite{Gree2014} argumenta que enfocarse en las pruebas y la medición hace un llamado a quienes tienen el poder de establecer las  pruebas, pero es poco probable mejorar los resultados
-a menos que esto se acompañe con apoyo para que las/los profesores realicen mejoras basadas en los resultados de las pruebas.
+\cite{Gree2014} argumenta que enfocarse en las evaluaciones y la medición hace un llamado a quienes tienen el poder de establecer las pruebas, pero es poco probable mejorar los resultados
+a menos que esto se acompañe con apoyo para que los/las docentes realicen mejoras basadas en los resultados de las pruebas.
 Esto último a menudo falta porque
 las grandes organizaciones usualmente valoran uniformidad por sobre la productividad ~\cite{Scot1998}.
 \end{aside}
@@ -113,13 +112,13 @@ El diseño inverso se describe como una secuencia,
 pero casi nunca se hace de esa manera.
 Podemos,
 por ejemplo, cambiar nuestra opinión acerca de lo que queremos enseñar
-en base a algo que se nos ocurre mientras estamos escribiendo un MCQ,
-o re-evaluar a quién estamos intentando ayudar una vez que tengamos un resumen de la lección.
+en base a algo que se nos ocurre mientras estamos escribiendo preguntas de opción múltiple,
+o re-evaluar a quién estamos intentando ayudar una vez que tengamos un esqueleto de la lección.
 Sin embargo,
-las notas que dejamos atrás deben presentar cosas en el orden descrito anteriormente para que quien tenga que usar o mantener la lección después de nosotras/nosotros pueda seguir sobre nuestro pensamiento
+las notas que dejamos atrás deben presentar las tareas desarrolladas en el orden descripto anteriormente, para que quien tenga que usar o mantener la lección pueda seguir nuestros razonamientos
 ~\cite{Parn1986}.
  
-\seclbl{Estudiante tipo}{s:process-personas}
+\seclbl{Estudiantes tipo}{s:process-personas}
  
 El primer paso en el proceso de diseño inverso es averiguar quién es tu audiencia.
 Una manera para hacer esto es escribir dos o tres

--- a/es/process.tex
+++ b/es/process.tex
@@ -203,7 +203,7 @@ descubrir cómo hacer que tu curso sea visible y pueda ser encontrado por tu pú
 Las evaluaciones formativas y sumativas ayudan a los/los docentes a descubrir qué van a enseñar,
 pero comunicarle eso a sus estudiantes y a otro conjunto de docentes
 implica tener también una descripción del curso.
-\grefdex{g:learning-objective}{learning objectives}{objetivos de aprendizaje}.
+Los \grefdex{g:learning-objective}{objetivos de aprendizaje}
 Los objetivos de aprendizaje ayudan a asegurar que
 todos/as tus estudiantes tengan el mismo entendimiento de lo que se supone que una lección debe lograr.
 Por ejemplo,

--- a/es/process.tex
+++ b/es/process.tex
@@ -91,7 +91,7 @@ También asegura que tus estudiantes no se enfrenten al final del curso
 a nada para lo que no tengan preparación.
  
 \begin{aside}{Incentivos perversos}
-La reingeniería \emph{no} es lo mismo que gref{g:teaching-to-the-test}{enseñar para el examen}.
+La reingeniería \emph{no} es lo mismo que \gref{g:teaching-to-the-test}{enseñar para el examen}.
 Cuando se usa reingeniería,
 los/las docentes establecen objetivos para ayudar en el diseño de sus lecciones:
 es posible que nunca den el examen final que preparan durante este proceso.

--- a/es/process.tex
+++ b/es/process.tex
@@ -194,7 +194,7 @@ en lugar de lo que tú crees que necesitan.
 Pregúntate lo que tus estudiantes están buscando en línea;
 probablemente no incluirá jerga que no conocen aún,
 así que parte de lo que tienes que hacer al diseñar lecciones es
-descubrir cómo hacer que tu curso sea visible y pueda ser encontrado por tu público. index{findability!of lessons}
+descubrir cómo hacer que tu curso sea visible y pueda ser encontrado por tu público.\index{findability!of lessons}
 \end{aside}
 
 

--- a/es/process.tex
+++ b/es/process.tex
@@ -200,20 +200,20 @@ descubrir cómo hacer que tu curso sea visible y pueda ser encontrado por tu pú
 
  \seclbl{Objetivos de aprendizaje}{s:process-objectives}
  
-Las evaluaciones formativas y sumativas ayudan a los/los docentes a descubrir lo que van a enseñar,
-pero para comunicar eso a sus estudiantes y a otro conjunto de docentes,
-debe tener también una descripción del curso.
+Las evaluaciones formativas y sumativas ayudan a los/los docentes a descubrir qué van a enseñar,
+pero comunicarle eso a sus estudiantes y a otro conjunto de docentes
+implica tener también una descripción del curso.
 \grefdex{g:learning-objective}{learning objectives}{objetivos de aprendizaje}.
 Los objetivos de aprendizaje ayudan a asegurar que
 todos/as tus estudiantes tengan el mismo entendimiento de lo que se supone que una lección debe lograr.
 Por ejemplo,
-una declaración como ``Entendiendo Git'' podría significar cualquiera de los siguientes ítems:
+el enunciado ``Entender Git'' podría significar cualquiera de los siguientes ítems:
  
 \begin{itemize}
  
 \item
   Los/las estudiantes pueden describir tres cuestiones
-  por las cuales los sistemas de versión de control como Git son mejores que herramientas para compartir archivos como Dropbox
+  en las cuales los sistemas de versión de control como Git son mejores que herramientas para compartir archivos como Dropbox
   y dos cuestiones en que son peores.
  
 \item
@@ -537,7 +537,7 @@ lo que incluye, por ejemplo, el uso de herramientas de línea de comandos con no
 Toma unos minutos para leer estos artículos,
 luego haz una lista de las rarezas no esenciales que crees
 que tus estudiantes podrían encontrar
-duando les enseñes por primera vez
+cuando les enseñes por primera vez
 ¿Cuántas de estas rarezas no esenciales puedes evitar?
  
 \exercise{Un patrón: problema, ejemplo, teoría y elaboración}{individual}{15'}

--- a/es/process.tex
+++ b/es/process.tex
@@ -204,7 +204,7 @@ Las evaluaciones formativas y sumativas ayudan a los/los docentes a descubrir qu
 pero comunicarle eso a sus estudiantes y a otro conjunto de docentes
 implica tener también una descripción del curso.
 Los \grefdex{g:learning-objective}{objetivos de aprendizaje}
-Los objetivos de aprendizaje ayudan a asegurar que
+ayudan a asegurar que
 todos/as tus estudiantes tengan el mismo entendimiento de lo que se supone que una lección debe lograr.
 Por ejemplo,
 el enunciado ``Entender Git'' podría significar cualquiera de los siguientes ítems:

--- a/es/process.tex
+++ b/es/process.tex
@@ -376,7 +376,7 @@ Un conjunto de objetivos de aprendizaje basados en la taxonomía de Fink para un
  
 \item
  Comparar y contrastar la escritura en lenguajes HTML y CSS
-con escribir con herramientas de edición de escritorio.
+con escribir con herramientas de escritorio de edición y publicación.
  
 \item
   Identificar y corregir problemas en páginas web de muestra

--- a/es/process.tex
+++ b/es/process.tex
@@ -27,7 +27,7 @@ En su lugar,
 escriben la prueba primero,
 luego escriben suficiente software nuevo para que esas pruebas pasen.
  
-Este método de programar funciona porque escribir pruebas obliga a
+Este método de programación funciona porque escribir pruebas obliga a
 tenér más precisión acerca de lo que están intentando lograr y cómo se ve ``finalizado''.
 El desarrollo impulsado por pruebas también evita el pulido sin fin:
 cuando pasan las pruebas, dejas de codificar.

--- a/es/process.tex
+++ b/es/process.tex
@@ -464,7 +464,7 @@ diseñados para estudiantes en niveles muy diferentes.
 \exercise{Crear personas tipo}{grupos pequeños}{30'}
  
 Trabajando en grupos pequeños,
-crea una persona tipo de cuatro puntos que describa a uno/a de tus estudiantes típicos.
+crea una persona tipo descripta con cuatro puntos que reseñe a uno/a de tus estudiantes típicos.
  
 \exercise{Clasificar objetivos de aprendizaje}{parejas}{10'}
  

--- a/es/process.tex
+++ b/es/process.tex
@@ -181,7 +181,7 @@ En lugar de escribir nuevas personas tipo para cada lección o curso,
 los/las docentes usualmente crean y comparten una media docena de personas tipo,
 que cubren a todas las personas a las que probablemente enseñan.
 Luego, eligen a algunas de esas personas tipo para describir al público de un material en particular.
-Las personas tipo utilizadas de estra manera se convierten en un conveniente atajo para los problemas de diseño:
+Las personas tipo utilizadas de esta manera se convierten en un atajo conveniente para los problemas de diseño:
 al hablar entre docentes, 
 se pueden pensar en términos del estilo
 ``¿Jorge entendería por qué estamos haciendo esto?''

--- a/es/process.tex
+++ b/es/process.tex
@@ -355,7 +355,7 @@ pero a diferencia de las de Bloom ellas son complementarias y no jerárquicas:
   \emph{(llegar a verse a sí mismo/a, entender a las demás personas en términos de, decidir transformarse en)}
  
 \item[Cuidado:]
-  Desarrollar nuevos sentimientos, intereses y valores
+  desarrollar nuevos sentimientos, intereses y valores
   \emph{(emocionarse, estar preparado/a para, valorar)}
  
 \item[Aprendiendo a aprender:]

--- a/es/process.tex
+++ b/es/process.tex
@@ -277,7 +277,7 @@ y provee contexto para asegurar que los resultados puedan evaluarse.
 \end{itemize}
  
 Cuando se trata de elegir verbos,
-la mayoría de los/las docentes usan la gref{g:blooms-taxonomía}{taxonomía de Bloom}.
+la mayoría de los/las docentes usan la \gref{g:blooms-taxonomía}{taxonomía de Bloom}.
 Publicada por primera vez en 1956 y actualizada a principios de siglo ~\cite{Ande2001},
 es un marco ampliamente usado para discutir los niveles de comprensión.
 Su forma más reciente tiene seis categorías;

--- a/es/process.tex
+++ b/es/process.tex
@@ -550,7 +550,8 @@ trabajar a través de un \emph{ejemplo},
 explicar la \emph{teoría},
 y luego \emph{elaborar} un segundo ejemplo
 para que los/las estudiantes puedan ver qué es específico en cada caso
-y qué se aplica a todos los casos.
+y qué se aplica a todos los casos. (En inglés se lo conoce por su sigla PETE: 
+\textbf{P}roblem, \textbf{E}xample, \textbf{T}heory, \textbf{E}laborate.)
 Elige algo que ya hayas enseñado o les hayan enseñado.
 y delinea una pequeña lección que siga estos cuatro pasos.
 .
@@ -564,6 +565,9 @@ Otro patrón de lección es ~\cite{Sent2019}:
 \emph{investigar} por qué lo hace pasando a través del mismo en un depurador o dibujando el flujo de control,
 \emph{modificar} el programa (o sus entradas),
 y luego \emph{crear} algo similar desde cero.
+\hreffoot{http://carpentries.github.io/instructor-training/}{el programa de entrenamiento de instructores/as de Software Carpentry}.
+(En inglés se lo conoce por su sigla PRIMM: 
+\textbf{P}redict, \textbf{R}un, \textbf{I}nvestigate, \textbf{M}odify, \textbf{M}ake.)
 Elige algo que hayas enseñado o te hayan enseñado recientemente
 y bosqueja una breve lección que siga estos cinco pasos.
  

--- a/es/process.tex
+++ b/es/process.tex
@@ -355,7 +355,7 @@ pero a diferencia de las de Bloom ellas son complementarias y no jerárquicas:
   \emph{(llegar a verse a sí mismo/a, entender a las demás personas en términos de, decidir transformarse en)}
  
 \item[Cuidado:]
-  desarrollar nuevos sentimientos, intereses y valores
+  desarrollar nuevos sentimientos, intereses y valores.
   \emph{(emocionarse, estar preparado/a para, valorar)}
  
 \item[Aprendiendo a aprender:]

--- a/es/process.tex
+++ b/es/process.tex
@@ -37,7 +37,7 @@ una persona que aún no ha escrito un fragmento de software
 será más objetiva que alguien que acaba de dedicar varias horas al trabajo duro y realmente quiere terminar.
  
 Un método similar denominado \gref{g:backward-design}{reingeniería} funciona muy bien para el diseño de lecciones.
-Este método fue desarrollado en forma independiente en ~\cite{Wigg2005,Bigg2011,Fink2013} y está resumido en~\cite{McTi2013}
+Este método fue desarrollado en forma independiente en ~\cite{Wigg2005,Bigg2011,Fink2013} y está resumido en~\cite{McTi2013}.
 En forma simplificada, sus pasos son:
  
 \begin{enumerate}

--- a/es/process.tex
+++ b/es/process.tex
@@ -565,7 +565,6 @@ Otro patrón de lección es ~\cite{Sent2019}:
 \emph{investigar} por qué lo hace pasando a través del mismo en un depurador o dibujando el flujo de control,
 \emph{modificar} el programa (o sus entradas),
 y luego \emph{crear} algo similar desde cero.
-\hreffoot{http://carpentries.github.io/instructor-training/}{el programa de entrenamiento de instructores/as de Software Carpentry}.
 (En inglés se lo conoce por su sigla PRIMM: 
 \textbf{P}redict, \textbf{R}un, \textbf{I}nvestigate, \textbf{M}odify, \textbf{M}ake.)
 Elige algo que hayas enseñado o te hayan enseñado recientemente

--- a/es/process.tex
+++ b/es/process.tex
@@ -375,7 +375,7 @@ Un conjunto de objetivos de aprendizaje basados en la taxonomía de Fink para un
   Diseñar una página web usando etiquetas comunes y propiedades de CSS.
  
 \item
- Comparar y contrastar la escritura en lenguajes HTML y CSS
+ Comparar y contrastar escribir en HTML y CSS
 con escribir con herramientas de escritorio de edición y publicación.
  
 \item

--- a/es/process.tex
+++ b/es/process.tex
@@ -440,7 +440,7 @@ Esta ecuación depende de cuatro factores:
   La razón es que una buena lección se parece más a una novela que a un programa:
   sus partes están estrechamente acopladas en lugar de ser cajas negras independientes.
   Por lo tanto, la reutilización directa de las lecciones puede ser un objetivo equivocado;
-  podríamos llegar más lejos tratando de hacerlas más fáciles de mezclar.
+  podríamos llegar más lejos tratando de hacerlas más fáciles de combinar.
  \end{description}
 
 Si la paradoja de reusabilidad es cierta,

--- a/es/process.tex
+++ b/es/process.tex
@@ -47,7 +47,7 @@ Crea o recicla personas tipo (concepto discutido en la siguiente sección)
 para imaginar a quiénes estás intentando ayudar y qué les atraerá.
 
  \item
-Haz un torbellino de ideas para tener una idea aproximada de lo que quieres cubrir,
+Haz una tormenta de ideas para tener una idea aproximada de lo que quieres cubrir,
 cómo lo vas a hacer,
 qué problemas o conceptos erróneos esperas encontrar,
 qué \emph{no} no se va a incluir, etcétera.

--- a/es/process.tex
+++ b/es/process.tex
@@ -107,7 +107,7 @@ Sin embargo, este tipo de apoyo no suele ocurrir ya que
 las grandes organizaciones usualmente valoran la uniformidad por sobre la productividad ~\cite{Scot1998}.
 \end{aside}
  
-El diseño inverso se describe como una secuencia,
+El diseño inverso (o diseño en retrospectiva) se describe como una secuencia,
 pero casi nunca se hace de esa manera.
 Podemos,
 por ejemplo, cambiar nuestra opinión acerca de lo que queremos enseñar

--- a/es/process.tex
+++ b/es/process.tex
@@ -443,7 +443,7 @@ Esta ecuación depende de cuatro factores:
   podríamos llegar más lejos tratando de hacerlas más fáciles de combinar.
  \end{description}
 
-Si la paradoja de reusabilidad es cierta,
+Si la paradoja de la reusabilidad es cierta,
 la colaboración será más probable
 si las cosas en las que se colabora son pequeñas.
 Esto se ajusta a la teoría de Mike Caulfield \index{Caulfield, Mike} de las

--- a/es/process.tex
+++ b/es/process.tex
@@ -20,16 +20,16 @@ para crear un examen final
 y te prometes que la próxima vez serás más organizado/a.
 \end{enumerate}
 
-Un método más efectivo es similar en esencia a una práctica de programación llamada \gref{g:test-driven-development}{desarrollo-impulsado-por pruebas}(TDD por sus siglas en inglés).
-Los/las programadores/as que usan TDD no escriben software
+Un método más efectivo es similar en esencia a una práctica de programación llamada \gref{g:test-driven-development}{desarrollo-impulsado-por pruebas}.
+Los/las programadores/as que usan desarrollo impulsado por pruebas no escriben software
 y luego prueban que funcione correctamente.
 En su lugar,
 escriben la prueba primero,
 luego escriben suficiente software nuevo para que esas pruebas pasen.
  
-El TDD funciona porque escribir pruebas obliga a quienes programan a
+Este método de programar funciona porque escribir pruebas obliga a
 tenér más precisión acerca de lo que están intentando lograr y cómo se ve ``finalizado''.
-El TDD también evita el pulido sin fin:
+El desarrollo impulsado por pruebas también evita el pulido sin fin:
 cuando pasan las pruebas, dejas de codificar.
 Finalmente,
 esto reduce el riesgo de sesgo de confirmación:
@@ -92,20 +92,19 @@ a nada para lo que no tengan preparación.
  
 \begin{aside}{Incentivos perversos}
 La reingeniería \emph{no} es lo mismo que gref{g:teaching-to-the-test}{enseñar para el examen}.
-Cuando se usa la reingeniería,
+Cuando se usa reingeniería,
 los/las docentes establecen objetivos para ayudar en el diseño de sus lecciones:
-es posible nunca den el examen final que preparan durante este proceso.
+es posible que nunca den el examen final que preparan durante este proceso.
 En muchos sistemas escolares,
 por otro lado,
 una autoridad externa define los criterios de evaluación para todos/as los/las estudiantes,
 independientemente de sus situaciones individuales.
 Los resultados de esas evaluaciones sumativas afectan directamente los salarios y las promociones de los/las docentes,
-lo que significa que el plantel docente tienen un incentivo para enfocarse en que sus estudiantes pasen las pruebas, y no en ayudarles a aprender.
+lo que significa que el plantel docente tiene un incentivo para que sus estudiantes pasen las pruebas, y no en ayudarles a aprender.
  
-\cite{Gree2014} argumenta que enfocarse en las evaluaciones y la medición hace un llamado a quienes tienen el poder de establecer las pruebas, pero es poco probable mejorar los resultados
-a menos que esto se acompañe con apoyo para que los/las docentes realicen mejoras basadas en los resultados de las pruebas.
-Esto último a menudo falta porque
-las grandes organizaciones usualmente valoran uniformidad por sobre la productividad ~\cite{Scot1998}.
+\cite{Gree2014} argumenta que, si bien enfocarse en las evaluaciones y la medición es atractivo para quienes tienen el poder de establecer las pruebas, es poco probable mejorar así los resultados del curso ---salvo que las evaluaciones se acompañen con apoyo para que los/las docentes realicen mejoras basadas en los resultados de las pruebas.
+Sin embargo, este tipo de apoyo no suele ocurrir ya que
+las grandes organizaciones usualmente valoran la uniformidad por sobre la productividad ~\cite{Scot1998}.
 \end{aside}
  
 El diseño inverso se describe como una secuencia,
@@ -115,137 +114,137 @@ por ejemplo, cambiar nuestra opinión acerca de lo que queremos enseñar
 en base a algo que se nos ocurre mientras estamos escribiendo preguntas de opción múltiple,
 o re-evaluar a quién estamos intentando ayudar una vez que tengamos un esqueleto de la lección.
 Sin embargo,
-las notas que dejamos atrás deben presentar las tareas desarrolladas en el orden descripto anteriormente, para que quien tenga que usar o mantener la lección pueda seguir nuestros razonamientos
+las notas que elaboremos deben presentar las tareas desarrolladas en el orden descripto anteriormente, para que quien tenga que usar o mantener la lección pueda seguir nuestros razonamientos
 ~\cite{Parn1986}.
  
 \seclbl{Personas tipo}{s:process-personas}
  
-El primer paso en el proceso de diseño inverso es averiguar quién es tu audiencia.
+El primer paso en el proceso de diseño inverso es averiguar quién es tu público.
 Una manera para hacer esto es escribir dos o tres
 \grefdex{g:learner-persona}{learner personas}{personas tipo}
-como los de \secref{s:intro-audience}.
-Esta técnica es tomada de diseñadores de experiencia de usuario,
-quienes crean perfiles breves de usuarios típicos
-para ayudarles a pensar en su audiencia.
+como los de la \secref{s:intro-audience}.
+Esta técnica es tomada de diseñadores/as de experiencia de usuario/a,
+quienes crean perfiles breves de usuarios/as típicos/as
+para ayudarse a pensar en su público.
 Una persona tipo consiste en:
  
 \begin{enumerate}
  
 \item
-antecedentes generales de la persona
+antecedentes generales de la persona;
  
 \item
-lo que ya saben;
+lo que ya sabe;
  
 \item
-lo que quieren hacer;
+lo que quiere hacer;
 y
  
 \item
-cualquier necesidad especial que tengan.
+cualquier necesidad especial que tenga.
  
 \end{enumerate}
- Las personas en \secref{s:intro-audience} tienen los cuatro puntos listados anteriormente,
-junto con un breve resumen de cómo este libro les ayudará.
-Una persona tipo para un grupo de voluntarios que realiza talleres de Python los fines de semana sería:
+ Las personas en la \secref{s:intro-audience} tienen los cuatro puntos listados anteriormente,
+junto con un breve resumen de cómo este libro las ayudará.
+Una persona tipo para un grupo de voluntarios/as que realiza talleres de Python los fines de semana sería:
  
 \begin{enumerate}
  
 \item
  Jorge se acaba de mudar de Costa Rica a Canadá para estudiar ingeniería agrícola.
-El se ha unido al equipo de fútbol universitario
+Se ha unido al equipo de fútbol de la universidad
 y espera aprender a jugar hockey sobre hielo.
  
 \item
-Aparte de usar Excel, Word y el internet,
+Aparte de usar Excel, Word e internet,
 la experiencia previa más significativa de Jorge con computadoras
 es ayudar a su hermana a construir un sitio en WordPress
-para el negocio familiar en casa.
+para su negocio familiar.
  
  
 \item
   Jorge quiere medir las propiedades del suelo en granjas cercanas
 usando un dispositivo de mano que envía datos a su computadora.
-Ahora mismo él tiene que abrir cada archivo de datos en Excel,
-eliminar la primera y la última columna,
-y calcular algunas estadísticas sobre lo que queda.
-El tiene que recopilar al menos 600 mediciones en los próximos meses
-y realmente no quiere tener que hacer estos pasos a mano para cada uno.
+Por el momento, Jorge tiene que abrir cada archivo de datos en Excel,
+eliminar la primera y la última columna
+y calcular algunas estadísticas de los datos restantes.
+Recopilará al menos 600 mediciones en los próximos meses
+y realmente no quiere tener que hacer estos pasos a mano mes a mes.
  
 \item
-Jorge puede leer Inglés bien,
-pero algunas veces le cuesta sostener una conversación hablada que involucre mucha jerga.
+Jorge puede leer en inglés,
+pero a veces le cuesta sostener una conversación hablada que involucre mucha jerga.
  
 \end{enumerate}
  
-En lugar de escribir nuevos tipos para cada lección o curso,
-las/los profesores usualmente crean y comparten media docena
-que cubren a todas las personas a las que probablemente enseñan,
-luego eligen algunos de ese conjunto para describir a la audiencia un material en particular.
-Los tipos que se usan de esta manera se convierten en un conveniente atajo para los problemas de diseño:
-Al hablar entre nosotras/os,
-las/los profesores pueden decir,
+En lugar de escribir nuevas personas tipo para cada lección o curso,
+los/las docentes usualmente crean y comparten una media docena de personas tipo,
+que cubren a todas las personas a las que probablemente enseñan.
+Luego, eligen a algunas de esas personas tipo para describir al público de un material en particular.
+Las personas tipo utilizadas de estra manera se convierten en un conveniente atajo para los problemas de diseño:
+al hablar entre docentes, 
+se pueden pensar en términos del estilo
 ``¿Jorge entendería por qué estamos haciendo esto?''
 o
 ``¿Qué problemas de instalación enfrentaría Jorge?''
  
 \begin{aside}{Sus metas, no las tuyas}
-Los tipo deberían siempre describir lo que la/el estudiante quiere hacer
-en lugar de lo que creen que necesitan.
-Pregúntate lo que ellas/ellos están buscando en línea;
+Las personas tipo deberían siempre describir lo que cada estudiante quiere hacer
+en lugar de lo que tú crees que necesitan.
+Pregúntate lo que tus estudiantes están buscando en línea;
 probablemente no incluirá jerga que no conocen aún,
-así que parte de lo que tienes que hacer como diseñadora/or instruccional es
-descubrir cómo hacer tu lección encontrable (visible). index{findability!of lessons}
+así que parte de lo que tienes que hacer al diseñar lecciones es
+descubrir cómo hacer que tu curso sea visible y pueda ser encontrado por tu público. index{findability!of lessons}
 \end{aside}
 
 
  \seclbl{Objetivos de aprendizaje}{s:process-objectives}
  
-Evaluaciones formativas y sumativas ayudan a las/los profesores a descubrir lo que van a enseñar,
-pero para comunicar eso a las/los estudiantes y otro conjunto de docentes,
+Las evaluaciones formativas y sumativas ayudan a los/los docentes a descubrir lo que van a enseñar,
+pero para comunicar eso a sus estudiantes y a otro conjunto de docentes,
 debe tener también una descripción del curso.
-\grefdex{g:learning-objective}{learning objectives}{objetivo de aprendizaje}.
-Estos ayudan a asegurar que
-todos tengan el mismo entendimiento de lo que se supone que una lección debe lograr.
+\grefdex{g:learning-objective}{learning objectives}{objetivos de aprendizaje}.
+Los objetivos de aprendizaje ayudan a asegurar que
+todos/as tus estudiantes tengan el mismo entendimiento de lo que se supone que una lección debe lograr.
 Por ejemplo,
-una declaración como ``entendiendo Git'' podría significar cualquiera de los siguientes ítemes:
+una declaración como ``Entendiendo Git'' podría significar cualquiera de los siguientes ítems:
  
 \begin{itemize}
  
 \item
-  Las/los estudiantes pueden describir tres maneras
-  en la cual los sistemas de versión de control como Git  son mejores que herramientas para compartir archivos como Dropbox
-  y dos formas que son las peores.
+  Los/las estudiantes pueden describir tres cuestiones
+  por las cuales los sistemas de versión de control como Git son mejores que herramientas para compartir archivos como Dropbox
+  y dos cuestiones en que son peores.
  
 \item
-Las/los estudiantes pueden hacer commit a un archivo modificado en un repositorio de Git
-usando una herramienta GUI de escritorio.
+Los/las estudiantes pueden hacer commit a un archivo modificado en un repositorio de Git
+usando un software con interfaz gráfica instalado en su computadora.
  
 \item
-  Las/los estudiantes pueden explicar qué es un HEAD por separado
+  Los/las estudiantes pueden explicar qué es un HEAD por separado
  y recuperarlo usando operaciones de línea de comandos.
  
 \end{itemize}
  
 
-\begin{aside}{Objetivos vs. Resultados}
+\begin{aside}{Objetivos versus resultados}
  Un objetivo de aprendizaje es lo que una lección se esmera por lograr.
  Un \gref{g:learning-outcome}{resultado de aprendizaje} es lo que realmente se logra,
- es decir, lo que las/los estudiantes realmente se llevan.
+ es decir, lo que tus estudiantes realmente se llevan.
 El rol de la evaluación sumativa es por lo tanto
-para comparar resultados de aprendizajes con objetivos de aprendizajes.
+comparar resultados de aprendizajes con objetivos de aprendizajes.
 \end{aside}
  
-Un objetivo de aprendizaje describe cómo la/el estudiante demostrará lo que ha aprendido
+Un objetivo de aprendizaje describe cómo tu estudiante demostrará lo que ha aprendido
 una vez que ha completado exitosamente una lección.
 Más específicamente,
-este tiene un \emph{verbo medible o verificable} que establece lo que la/el estudiante hará
+un objetivo tiene un \emph{verbo medible o verificable} que establece lo que cada estudiante hará
 y especifica los \emph{criterios aceptables de rendimiento}.
-Escribirlos puede inicialmente parecer restrictivo,
-pero ellos te harán a ti,
-a tus compañeras/compañeros docentes,
-y a tus estudiantes más felices a largo plazo:
-terminarás con guías claras tanto para su enseñanza como para su evaluación,
+Escribir estos objetivos puede inicialmente parecer restrictivo,
+pero a largo plazo te hará más feliz a ti,
+a tus colegas docentes
+y a tus estudiantes:
+terminarás con guías claras tanto para la enseñanza como para la evaluación,
 y tus estudiantes apreciarán tener expectativas claras.
 
 Una forma de comprender lo que constituye un buen objetivo de aprendizaje
@@ -254,41 +253,41 @@ es ver cómo se puede mejorar uno pobre:
  \begin{itemize}
  
 \item
-  \emph{La/el estudiante tendrá oportunidad para aprender buenas prácticas de programación.}\\
-Esto describe el contenido de la lección,
-no los atributos de éxito de las/los estudiantes.\\
+  \emph{El/la estudiante tendrá oportunidad para aprender buenas prácticas de programación.}\\
+Este enunciado describe el contenido de la lección,
+no los atributos de éxito de tus estudiantes.\\
  
 \item
-  \emph{La/el estudiante tendrá una mejor apreciación
+  \emph{El/la estudiante tendrá una mejor apreciación
 de las buenas prácticas de programación.}\\
- Esto no empieza con un verbo activo ni define el nivel de aprendizaje,
-y el tema de aprendizaje no tiene contexto y no es específico.\\
+ Este enunciado no empieza con un verbo activo ni define el nivel de aprendizaje.
+ El tema de aprendizaje no tiene contexto y no es específico.\\
  
 \item
-  \emph{La/el estudiante comprenderá cómo programar en R.}\\
-  Si bien esto comienza con un verbo activo,
-   no define el nivel de aprendizaje,
-  y el tema de aprendizaje es todavía demasiado vago para evaluarlo.\\
+  \emph{El/la estudiante comprenderá cómo programar en R.}\\
+  Si bien aquí se comienza con un verbo activo,
+   no se define el nivel de aprendizaje,
+  y el tema de aprendizaje es todavía demasiado vago para una evaluación.\\
  
 \item
-  \emph{La/el estudiante escribirá scripts de análisis de datos para leer, filtrar y resumir datos tabulares usando R.}\\
- Esto comienza con un verbo activo,
+  \emph{El/la estudiante escribirá scripts de análisis de datos para leer, filtrar y resumir datos tabulares usando R.}\\
+ Este objetivo comienza con un verbo activo,
 define el nivel de aprendizaje
 y provee contexto para asegurar que los resultados puedan evaluarse.
 \end{itemize}
  
 Cuando se trata de elegir verbos,
-la mayoría de docentes usan la gref{g:blooms-taxonomía}{Taxonomía de Bloom}.
-Publicado por primera vez en 1956 y actualizado a principios de siglo ~\cite{Ande2001},
+la mayoría de los/las docentes usan la gref{g:blooms-taxonomía}{taxonomía de Bloom}.
+Publicada por primera vez en 1956 y actualizada a principios de siglo ~\cite{Ande2001},
 es un marco ampliamente usado para discutir los niveles de comprensión.
-Su forma más reciente tiene 6 categorías;
+Su forma más reciente tiene seis categorías;
 la lista a continuación da algunos de los verbos típicamente usados en los objetivos de aprendizaje escritos para cada uno:
 
 
 \begin{description}
  
 \item[Recordar:]
-  Demostrar memoria del  material previamente aprendido
+  Exhibir memoria del  material previamente aprendido
 recordando hechos, términos,
 conceptos básicos y respuestas.
   \emph{(reconocer, listar, describir, nombrar, encontrar.)}
@@ -299,8 +298,8 @@ organizando, comparando, traduciendo, interpretando, dando descripciones y estab
   \emph{(interpretar, resumir, parafrasear, clasificar, explicar)}
  
 \item[Aplicar:]
-  Resolver problemas nuevos aplicando los conocimientos,
-hechos, técnicas y reglas adquiridos de una forma diferente
+  Resolver problemas nuevos aplicando de forma diferente los conocimientos,
+hechos, técnicas y reglas adquiridos.
   \emph{(construir, identificar, usar, planificar, seleccionar)}
  
 \item[Analizar:]
@@ -310,8 +309,8 @@ hechos, técnicas y reglas adquiridos de una forma diferente
  
 \item[Evaluar:]
   Presentar y defender opiniones emitiendo juicios sobre información,
-  validez de las ideas,
-o calidad del trabajo basada en un conjunto de criterios.
+  validez de las ideas
+o calidad del trabajo, en base a un conjunto de criterios.
   \emph{(comprobar, elegir, criticar, probar, calificar)}
  
 \item[Crear:]
@@ -321,22 +320,21 @@ combinando elementos en un nuevo patrón o proponiendo soluciones alternativas.
  
 \end{description}
  
-La Taxonomía de Bloom aparece en casi todos los libros de texto sobre educación,
+La taxonomía de Bloom aparece en casi todos los libros de texto sobre educación,
 pero ~\cite{Masa2018} encontró que
-Incluso los educadores experimentados tienen problemas para ponerse de acuerdo
-sobre cómo clasificar cosas específicas.
-Los verbos siguen siendo útiles,
-aunque,
-al igual que la noción de construir la comprensión en pasos:
+incluso los/las educadores/as con mucha experiencia tienen problemas para ponerse de acuerdo
+en cómo clasificar cuestiones específicas.
+Sin embargo, los verbos siguen siendo útiles, tal como sucede con
+la noción de construir la comprensión en pasos:
 como Daniel Willingham ha dicho, \index{Willingham, Daniel}
-la gente no puede pensar sin algo en qué pensar ~\cite{Will2010},
-y esta taxonomía puede ayudar a las/los docentes a asegurarse
-que las/los estudiantes tengan esas cosas cuando las necesiten.
+la gente no puede pensar si no tiene algo en qué pensar ~\cite{Will2010},
+y esta taxonomía puede ayudar a los/las docentes a asegurarse
+que sus estudiantes tienen esas cosas en qué pensar para cuando las necesiten.
 
-Otra manera de pensar acerca de los objetivos de aprendizaje proviene de ~\cite{Fink2013},
-el cual define aprendizaje en términos del cambio que se supone que debe producirse en la/el estudiante.
-La \gref{g:finks-taxonomy}{Taxonomía de Fink} también tiene seis categorías,
-pero a diferencia de las de Bloom ellas son complementarias en lugar de jerárquicas:
+Otra manera de conceptualizar los objetivos de aprendizaje proviene de ~\cite{Fink2013},
+el cual define aprendizaje en términos del cambio que se supone que debe producirse en el/la estudiante.
+La \gref{g:finks-taxonomy}{taxonomía de Fink} también tiene seis categorías,
+pero a diferencia de las de Bloom ellas son complementarias y no jerárquicas:
  
 \begin{description}
  
@@ -352,21 +350,21 @@ pero a diferencia de las de Bloom ellas son complementarias en lugar de jerárqu
   conectar ideas, experiencias de aprendizaje y vida real
   \emph{(conectar, relatar, comparar)}
  
-\item[Dimensión Humana:]
-  Aprender sobre sí misma/mismo y otras/otros.
-  \emph{(llegar a verse a sí misma/mismo, entender a las/los demás en términos de, decidir ser)}
+\item[Dimensión humana:]
+  Aprender sobre sí mismo/a y sobre otras personas.
+  \emph{(llegar a verse a sí mismo/a, entender a las demás personas en términos de, decidir transformarse en)}
  
-\item[Cuidando:]
+\item[Cuidado:]
   Desarrollar nuevos sentimientos, intereses y valores
-  \emph{(emocionarse, estar preparada/preparado para, valorar)}
+  \emph{(emocionarse, estar preparado/a para, valorar)}
  
 \item[Aprendiendo a aprender:]
-  Convertirse en una/un mejor estudiante.
+  Convertirse en mejor estudiante.
   \emph{(identificar la fuente de información para, enmarcar preguntas útiles sobre)}
  
 \end{description}
  
-Un conjunto de objetivos de aprendizaje basados en esta taxonomía para un curso introductorio sobre HTML y CSS sería:
+Un conjunto de objetivos de aprendizaje basados en la taxonomía de Fink para un curso introductorio sobre HTML y CSS sería:
  
 \begin{itemize}
  
@@ -377,8 +375,8 @@ Un conjunto de objetivos de aprendizaje basados en esta taxonomía para un curso
   Diseñar una página web usando etiquetas comunes y propiedades de CSS.
  
 \item
- Comparar y contrastar la escritura de HTML y CSS
-para escribir con herramientas de edición de escritorio.
+ Comparar y contrastar la escritura en lenguajes HTML y CSS
+con escribir con herramientas de edición de escritorio.
  
 \item
   Identificar y corregir problemas en páginas web de muestra
@@ -387,44 +385,44 @@ para escribir con herramientas de edición de escritorio.
 \item
 Describir las características de los sitios web favoritos
 cuyo diseño te atraiga de forma particular
-y explica el por qué.
+y explicar el por qué.
  
 \item
-  Describir tus dos fuentes de información favoritas en línea acerca
-de CSS y explica qué te gusta de ellas.
+  Describir tus dos fuentes de información en línea favoritas sobre
+CSS y explicar qué te gusta de ellas.
  
 \end{itemize}
  
 \seclbl{Mantenimiento}{s:process-maintainability}
  
-Una vez que una lección ha sido creada alguien debe mantenerla,
+Una vez que una lección ha sido creada alguien debe mantenerla
 y hacerlo es mucho más fácil si se ha construido de manera que se pueda mantener.
-¿Pero qué significa exactamente ``mantenible´´? \index{ maintainability (of lessons)}
+Pero, ¿qué significa exactamente ``mantenible´´? \index{maintainability (of lessons)}
 La respuesta corta es que una lección es mantenible
 si es más barato actualizarla que reemplazarla.
-Esta ecuación depende de 4 factores:
+Esta ecuación depende de cuatro factores:
  
 \begin{description}
  
-\item[¿Qué tan bien documentado está el diseño del curso?]
+\item[Qué tan bien documentado está el diseño del curso]
   Si la persona que realiza el mantenimiento no conoce (o no recuerda)
-  lo que se supone la lección debe lograr,
+  lo que se supone que la lección debe lograr
   o por qué los temas son presentados en un orden en particular,
   le llevará más tiempo actualizarla.
   Una razón para usar el diseño inverso
   es captar decisiones sobre por qué cada curso es como es.
  
-\item[¿Qué tan fácil es para los colaboradores ayudar?]
-  Las/los docentes suelen compartir material enviándose por correo archivos de PowerPoint entre ellas/ellos o poniéndolos en una unidad compartida.
-  Herramientas de escritura colaborativa como \hreffoot{http://docs.google.com}{\emph{Google Docs}} and wikis
+\item[Qué tan fácil es para los colaboradores ayudar]
+  Los/las docentes suelen compartir material enviándose por correo archivos de PowerPoint o dejándolos en una unidad compartida.
+  Herramientas de escritura colaborativa como \hreffoot{http://docs.google.com}{\emph{Google Docs}} y wikis
   son una gran mejora,
   ya que permiten que muchas personas actualicen el mismo documento
   y comenten las actualizaciones de otras personas.
-  El sistema de control de versiones usado por programadores,
+  Los sistemas de control de versiones usados por programadores/as,
   tales como \hreffoot{http://github.com}{\emph{GitHub}},
   son otro enfoque.
-  Permiten que cualquier número de personas trabajen de forma independiente
-  y luego unir sus cambios en forma controlada y revisable.
+  Permiten que cualquier número de personas trabaje de forma independiente,
+  para luego unir sus cambios en forma controlada y revisable.
   Desafortunadamente,
   los sistemas de control de versión tienen una curva de aprendizaje pronunciada
    y no manejan formatos de documentos de oficina comunes.
@@ -432,33 +430,33 @@ Esta ecuación depende de 4 factores:
 \item[Qué tan dispuestas están las personas a colaborar.]
   Las herramientas necesarias para construir un Wikipedia para lecciones
   existen hacen veinte años,
-  pero la mayoría de docentes no escriben ni comparten sus lecciones
+  pero la mayoría de los/las docentes no escriben ni comparten sus lecciones
   de la misma manera en que escriben y comparten las entradas de enciclopedias.
  
 \item[Qué tan útil es compartir en realidad.]
-  La \gref{g:reusability-paradox}{Paradoja de la Reusabilidad} establece que
+  La \gref{g:reusability-paradox}{paradoja de la reusabilidad} establece que
   cuanto más reutilizable es un objetivo de aprendizaje,
   menos efectivo pedagógicamente es ~\cite{Wile2002}.
   La razón es que una buena lección se parece más a una novela que a un programa:
   sus partes están estrechamente acopladas en lugar de ser cajas negras independientes.
-  Por lo tanto, la reutilización directa puede ser el objetivo equivocado de las lecciones;
+  Por lo tanto, la reutilización directa de las lecciones puede ser un objetivo equivocado;
   podríamos llegar más lejos tratando de hacerlas más fáciles de mezclar.
  \end{description}
 
-Si la paradoja de Reusabilidad es cierta,
+Si la paradoja de reusabilidad es cierta,
 la colaboración será más probable
 si las cosas en las que se colabora son pequeñas.
-Esto se ajusta a la teoría de Mike Caulfield \index{Caulfield, Mike}
-\hreffoot{https://hapgood.us/2016/05/13/choral-explanations/}{\emph{choral explanations}}(explicaciones corales),
+Esto se ajusta a la teoría de Mike Caulfield \index{Caulfield, Mike} de las
+\hreffoot{https://hapgood.us/2016/05/13/choral-explanations/}{\emph{explicaciones corales}},
 que sostiene que sitios como
 \hreffoot{https://stackoverflow.com/}{\emph{Stack Overflow}} tienen éxito porque
 proporcionan un coro de respuestas para cada pregunta,
 cada una de las cuales es más adecuada para
-una persona que pregunta y que es ligeramente diferente a las demás que preguntan.
-Si esto es correcto
-las lecciones de mañana puedes ser visitas guiadas de repositorios
-de preguntas y respuestas seleccionadas por la comunidad
-diseñadas para estudiantes en niveles muy diferentes.
+una persona que pregunta y que es ligeramente diferente a las demás personas que preguntan.
+Si esto es correcto,
+las lecciones del futuro pueden ser visitas guiadas de repositorios
+de preguntas y respuestas seleccionados por la comunidad,
+diseñados para estudiantes en niveles muy diferentes.
  
  
 \seclbl{Ejercicios}{s:process-exercises}
@@ -466,120 +464,120 @@ diseñadas para estudiantes en niveles muy diferentes.
 \exercise{Crear personas tipo}{grupos pequeños}{30'}
  
 Trabajando en grupos pequeños,
-crea un tipo de 4 puntos que describa a una/uno de sus estudiantes estándar.
+crea una persona tipo de cuatro puntos que describa a uno/a de tus estudiantes típicos.
  
 \exercise{Clasificar objetivos de aprendizaje}{parejas}{10'}
  
-Mira el ejemplo de objetivos de aprendizaje
+Mira el ejemplo de los objetivos de aprendizaje
 para un curso introductorio sobre HTML y CSS
-en \secref{s:process-objectives}
-y clasifica cada uno de acuerdo a la Taxonomía de Bloom.
-Compara tus respuestas con las de tu compañera/o.
-¿Dónde estuvieron de acuerdo y en desacuerdo?
+en la \secref{s:process-objectives}
+y clasifica cada uno de acuerdo a la taxonomía de Bloom.
+Compara tus respuestas con las de tu pareja.
+¿En qué estuvieron de acuerdo y en desacuerdo?
  
 \exercise{Escribir objetivos de aprendizaje}{parejas}{20'}
  
 Escribe uno o más objetivos de aprendizaje
-para algo que actualmente enseñas o planeas enseñar
-utilizando la Taxonomía de Bloom.
-Trabajando con otra persona,
+para un tema que actualmente enseñes o planees enseñar
+utilizando la taxonomía de Bloom.
+Con tu pareja,
 critica y mejora los objetivos.
-¿Cada uno tiene un verbo verificable y establece claramente
-los criterios  para un desempeño aceptable?
+¿Cada objetivo tiene un verbo verificable y establece claramente
+los criterios para evaluar el desempeño como aceptable?
  
-\exercise{Escribir más Objetivos de Aprendizaje}{parejas}{20'}
+\exercise{Escribir más objetivos de aprendizaje}{parejas}{20'}
  
 Escribe uno o más objetivos de aprendizaje
-para algo que actualmente enseñas o planeas enseñar
-utilizando la Taxonomía de Fink.
-Trabajando en pareja,
+para algo que actualmente enseñes o planees enseñar
+utilizando la taxonomía de Fink.
+Con tu pareja,
 critica y mejora los objetivos.
  
-\exercise{Ayúdame a hacerlo sola/o}{grupos pequeños}{15'}
+\exercise{Ayúdame a hacerlo por mi cuenta}{grupos pequeños}{15'}
  
 El teórico de la educación Lev Vygotsky introdujo la noción de una
-\gref{g:zpd}{Zona de Desarrollo Proximal} (ZPD por sus siglas en inglés),
+\gref{g:zpd}{zona de desarrollo próximo},
 la cual incluye los problemas que las personas no pueden resolver aún por sí mismas
-pero que son capaces de resolver con la ayuda de una mentora/un mentor.
-Estos son los problemas que resultan más fructíferos abordar a continuación,
-ya que están fuera de tu alcance pero son alcanzables.
+pero que son capaces de resolver con la ayuda de un mentor/a.
+Se trata de problemas que resulta fructífero abordar a corto plazo,
+ya que aún están fuera del alcance de tu estudiante pero son alcanzables.
  
 Trabajando en grupos pequeños,
 escoge una persona tipo que hayas desarrollado
-y describe dos o tres problemas que se encuentran en la ZPD de esa/ese estudiante.
+y describe dos o tres problemas que se encuentran en su zona de desarrollo próximo.
  
-\exercise{Construyendo lecciones, restando complejidad}{individual}{20'}
+\exercise{Restar complejidad al construir lecciones}{individual}{20'}
  
 Una forma para construir una lección de programación
-es escribir el programa que deseas que las/los estudiantes terminen,
-luego elimina la parte más compleja que deseas que escriban
-y conviértela en el último ejercicio.
-Tú puedes luego remover la siguiente parte más compleja que deseas que escriban
-y conviértela en el penúltimo ejercicio, etc.
+es escribir el programa que deseas que tus estudiantes terminen,
+luego eliminar la parte más compleja que deseas que escriban
+y convertirla en el último ejercicio.
+A continuación puedes eliminar la siguiente parte más compleja que deseas que escriban
+y convertirla en el penúltimo ejercicio, etcétera.
 Todo lo que quede después de haber retirado los ejercicios,
 como cargar librerias o leer datos,
-se convierte en el código al inicio les das.
+se convierte en el código que les das al inicio.
  Elige un programa o página web que desees que
-tus estudiantes puedan crear,
-y trabaja hacia atrás para dividirlo en partes que se asimilen.
-¿Cuántos hay?
+tus estudiantes puedan crear
+y trabaja hacia atrás para dividirlo en fragmentos que se asimilen.
+¿Cuántos fragmentos hay?
 ¿Qué idea clave introduce cada uno?
  
 \exercise{Rareza no esencial}{individual}{15'}
  
 Betsy Leondar-Wright acuñó la frase
-``\hreffoot{http://www.classmatters.org/2006\_07/its-not-them.php}{\emph{inessential weirdness }}''(rareza no esencial)
+``\hreffoot{http://www.classmatters.org/2006\_07/its-not-them.php}{\emph{rareza no esencial}}''
 para describir cosas que hacen los grupos
-que no son realmente necesarias,
-pero que alienan a personas que aún no son miembros de ese grupo
+que no son realmente necesarias y
+que alienan a personas que aún no son integrantes de ese grupo.
 Sumana Harihareswara luego usó esta noción
 como base para una charla sobre
-\hreffoot{https://www.harihareswara.net/sumana/2016/05/21/0}{\emph{inessential weirdnesses in open source software}}(rarezas no esenciales en el software de código abierto),
-que incluye códigos como el uso de herramientas de línea de comandos con nombres crípticos.
+\hreffoot{https://www.harihareswara.net/sumana/2016/05/21/0}{\emph{rarezas no esenciales en el software de código abierto}},
+lo que incluye, por ejemplo, el uso de herramientas de línea de comandos con nombres crípticos.
 Toma unos minutos para leer estos artículos,
 luego haz una lista de las rarezas no esenciales que crees
 que tus estudiantes podrían encontrar
-Cuando les enseñes por primera vez
-¿Cuántas de estas puedes evitar?
+duando les enseñes por primera vez
+¿Cuántas de estas rarezas no esenciales puedes evitar?
  
-\exercise{PETE}{individual}{15'}
-\index{PETE (lesson pattern)}
+\exercise{Un patrón: problema, ejemplo, teoría y elaboración}{individual}{15'}
+\index{PETE(lesson pattern)}
 \index{lesson pattern!PETE}
 
-Un patrón que trabaja bien para lecciones de programación es PETE:
-Introduce el  \textbf{P}roblema,
-trabaja a través de un \textbf{E}jemplo,
-explica la \textbf{T}eoría,
-y luego \textbf{E}labora un Segundo ejemplo
-para que las/los estudiantes puedan ver qué es específico en cada caso
+Un patrón que trabaja bien para lecciones de programación es:
+presentar un \emph{problema},
+trabajar a través de un \emph{ejemplo},
+explicar la \emph{teoría},
+y luego \emph{elaborar} un segundo ejemplo
+para que los/las estudiantes puedan ver qué es específico en cada caso
 y qué se aplica a todos los casos.
 Elige algo que ya hayas enseñado o les hayan enseñado.
-Y delinea una pequeña lección que siga estos cinco pasos.
+y delinea una pequeña lección que siga estos cuatro pasos.
 .
-\exercise{PRIMM}{individual}{15'}
+\exercise{Otro patrón: predecir, ejecutar, investigar, modificar y crear}{individual}{15'}
 \index{PRIMM (lesson pattern)}
 \index{lesson pattern!PRIMM}
 
-Otro patrón de lección es PRIMM~\cite{Sent2019}:
-\textbf{P}redecir el comportamiento o salida de un programa,
-Correr, del inglés \textbf{R}un, el programa para ver lo que realmente hace,
-\textbf{I}nvestigar por qué lo hace pasando a través del mismo en un depurador o dibujando el flujo de control.
-\textbf{M}odificar el programa (o sus entradas),
-y luego hacer, del inglés \textbf{M}ake, algo similar desde cero.
+Otro patrón de lección es ~\cite{Sent2019}:
+\emph{predecir} el comportamiento o salida de un programa,
+\emph{ejecutar} el programa para ver lo que realmente hace,
+\emph{investigar} por qué lo hace pasando a través del mismo en un depurador o dibujando el flujo de control,
+\emph{modificar} el programa (o sus entradas),
+y luego \emph{crear} algo similar desde cero.
 Elige algo que hayas enseñado o te hayan enseñado recientemente
-y bosqueja una breve lección que siga los siguientes cinco pasos.
+y bosqueja una breve lección que siga estos cinco pasos.
  
-\exercise{Concreto-Figurativo-Abstracto}{parejas}{15'}
+\exercise{Concreto-representativo-abstracto}{parejas}{15'}
 \index{CRA (lesson pattern)}
 \index{lesson pattern!CRA}
  
  
-\hreffoot{https://makingeducationfun.wordpress.com/2012/04/29/concrete-representational-abstract-cra/}{ \emph{Concrete-Representational-Abstract }} (Concreto-Representativo-Abstracto) (CRA), por sus siglas en inglés, es un enfoque para introducir nuevas ideas
+\hreffoot{https://makingeducationfun.wordpress.com/2012/04/29/concrete-representational-abstract-cra/}{ \emph{Concreto-representativo-abstracto}} es un enfoque para introducir nuevas ideas
 que es usado principalmente con estudiantes más jóvenes:
-manipular físicamente un objeto \textbf{C}oncreto,
-\textbf{R}epresentar el objeto con una imagen,
+manipular físicamente un objeto \emph{concreto},
+\emph{representar} el objeto con una imagen,
 luego realizar las mismas operaciones
-usando números, símbolos o algo \textbf{A}bstracto.
+usando números, símbolos o algo \emph{abstracto}.
  \begin{enumerate}
  
 \item
@@ -589,48 +587,46 @@ usando números, símbolos o algo \textbf{A}bstracto.
   Simula un bucle que encuentre el valor más grande buscando cada uno por turno (concreto).
  
 \item
- Dibuja un diagrama del proceso que usaste etiquetando cada paso (representativo)
+ Dibuja un diagrama del proceso que usaste etiquetando cada paso (representativo).
  
 \item
-  Escribe instrucciones que alguien más podría seguir por medio de los pasos (abstracto)
+  Escribe instrucciones que alguien más podría seguir por medio de los pasos (abstracto).
 \end{enumerate}
  
  
-Compara tus materiales representativo y abstracto con tus compañeras/compañeros.
+Compara tus materiales representativos y abstractos con los de tu colega.
  
 \exercise{Evaluación de un repositorio de lecciones}{grupos pequeños}{10'}
  
-\cite{Leak2017} explora por qué las/los docentes de ciencias computacionales
+\cite{Leak2017} explora por qué los/las docentes de ciencias de la computación
 no utilizan sitios para compartir lecciones y recomienda formas para hacerlas más atractivas:
  
 \begin{enumerate}
  
 \item
-  La página de destino debe permitir a los visitantes del sitio
-identificar sus antecedentes y sus intereses al visitarlo.
+  La página de destino debe permitir a quienes visitan el sitio
+identificar sus antecedentes y sus intereses.
 Los sitios deben hacer dos preguntas:
-``¿Cuál es su función actual? '' y
-``¿En qué curso y grado estás interesada/o? ''
+``¿Cuál es tu rol actual? '' y
+``¿En qué curso y nivel tienes interés? ''
  
 \item
-  Los sitios deben mostrar todos los recursos de aprendizaje
-en el contexto del curso completo para que los usuarios potenciales puedan comprender
-su contexto de uso previsto.
+  Los sitios deben mostrar los recursos de aprendizaje
+en el marco de un curso completo para que los/las usuarios/as potenciales puedan comprender
+el contexto en que se prevé usar el material.
  
 \item
-  A muchas/muchos docentes les preocupa que sus pares
-juzguen su (falta de) conocimiento si publican en los foros de discusión
-de los sitios.
-Por tanto, estos foros deberían permitir la publicación anónima.
+  A muchos/as docentes les preocupa que sus pares
+juzguen su (falta de) conocimiento si publican en foros de discusión
+en línea.
+Por tanto, estos foros deberían permitir publicaciones anónimas.
 \end{enumerate}
 
 En grupos pequeños,
-Discute si estas tres características serían
-suficientes para convencerte de usar un sitio para compartir lecciones,
-y si no,
-lo que haría.
+discute si estas tres características serían
+suficientes para convencerte de usar un sitio para compartir lecciones. Si no fueran suficientes, ¿qué te convencería?
 
  
 \section*{Revisión}
  
-\figpdfhere{figures/conceptmap-personas.pdf}{Concepto: Estudiantes}{f:process-personas}
+\figpdfhere{figures/conceptmap-personas.pdf}{Concepto: personas tipo}{f:process-personas}

--- a/es/process.tex
+++ b/es/process.tex
@@ -351,7 +351,7 @@ pero a diferencia de las de Bloom ellas son complementarias y no jerárquicas:
   \emph{(conectar, relatar, comparar)}
  
 \item[Dimensión humana:]
-  Aprender sobre sí mismo/a y sobre otras personas.
+  aprender sobre sí mismo/a y sobre otras personas.
   \emph{(llegar a verse a sí mismo/a, entender a las demás personas en términos de, decidir transformarse en)}
  
 \item[Cuidado:]


### PR DESCRIPTION
Segunda revisión y edición general de **process.tex**:

- "learner persona" se traduce como "persona tipo" (plural "personas tipo").

- el capítulo tenía mayormente al revés los/las (usaba las/los), revisión general de lenguaje no sexista.

- Desarrollo impulsado por pruebas: quité la sigla TDD.

- zona de desarrollo próximo (en vez de proximal), así está en wikipedia. Quité la sigla.

- quité la sigla PETE del título 😬, fijate si te parece bien cómo quedaría la traducción.
Al principio había quitado toda mención a la sigla, pero se perdía un poco el concepto y no sé cuán conocido es.
Ahora dejé la aclaración en inglés. 
Otra posibilidad era dejar una sigla en castellano porque ayuda a recordar el patrón, la alternativa que se me ocurre es cambiar PETE por PECE: problema, ejemplo, **c**onceptos teóricos (en vez de teoría) y elaboración. En ese caso también habría que cambiar la sgte sigla PRIMM.

- chequear: "Pick something you have recently taught or been taught and outline a short lesson for it that follows these **five** steps." Cuento **cuatro** pasos! Lo traduje como cuatro. Ver si sugerimos edición en inglés.

- por consistencia con PETE, quité la sigla PRIMM del título, dejé aclaración en inglés. Cambié la traducción. Revisala :)
- quité CRA porque no se usa tanto y no es un patrón a recordar

- en la explicación de las traducciones de PETE, PRIMM y CRA, pasé de negritas a itálicas (porque eliminé las siglas).
