### PR TITLE
Revision of pck.tex - [es] 

### DIFF
--- a/es/pck.tex
+++ b/es/pck.tex
@@ -107,7 +107,7 @@ muchas/os estudiantes no saben cómo programar al final de los cursos introducto
 Más específicamente,
 ``Para una muestra combinada de 216 estudiantes de cuatro universidades,
 la puntuación media fue de 22,89 sobre 110 puntos en los criterios generales de evaluación desarrollados para este estudio.''
-Este resultado puede hablar tanto de las expectativas de profesores como de la habilidad de las/los estudiantes,
+Este resultado puede hablar tanto de las expectativas de docentes como de la habilidad de las/los estudiantes,
 pero de cualquier manera,
 nuestra primera recomendación es \recommendation{mide y haz un seguimiento de los resultados}
 de tal manera que se puedan comparar a través del tiempo para que puedas saber si tus lecciones se están volviendo más o menos efectivas.

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -49,7 +49,7 @@ Pero dado que las/los docentes reales que enseñan en aulas reales tienen que to
 
 \begin{aside}{Jerga}
   Como cualquier especialidad,
-  la investigación sobre educación en informárica tiene jerga.
+  la investigación sobre educación en informática tiene jerga.
   \gref{g:cs1}{CS1} refiere a un curso introductorio de un semestre de duración, donde los estudiantes aprenden variables, bucles y funciones por primera vez, mientras que \gref{g:cs2}{CS2} refiere a un segundo curso que cubre las estructuras de datos básicas como pilas y colas, 
   y \gref{g:cs0}{CS0} se refiere a un curso introductorio para personas sin experiencia previa y que no tienen intención de continuar con computación de inmediato.
   Las definiciones completas de estos términos se encuentran en los \hreffoot{https://www.acm.org/education/curricula-recommendations}{lineamientos del programa ACM}.
@@ -365,9 +365,9 @@ las diferencias son mayores.
 \begin{aside}{Más difícil de lo necesario}
   Las personas que crean lenguajes de programación hacen que esos lenguajes sean más difíciles de aprender al no realizar pruebas básicas de usabilidad.
   Por ejemplo,
-  \cite{Stef2013} encontró que,
+  \cite{Stef2013} encontraron que,
   ``{\ldots}las tres palabras más comunes para generar bucles en ciencias de la computación,
-  \texttt{for}, \texttt{while}, and \texttt{foreach},
+  \texttt{for}, \texttt{while} y \texttt{foreach},
   fueron calificadas como las tres opciones más anti-intuitivas por personas que no programan.''
   Su trabajo muestra que sintaxis al estilo de C (como se usa en Java y Perl)
   son tanto más difíciles de aprender para personas novatas como una sintaxis diseñada de manera aleatoria,
@@ -385,9 +385,9 @@ las diferencias son mayores.
 Los objetos y clases son herramientas poderosas para personas con experiencia en programación,
 y muchas/os docentes promueven un enfoque de \gref{g:objects-first}{primero objetos} para enseñar a programar
 (aunque a veces no concuerdan exactamente con lo que eso significa~\cite{Benn2007b}).
-\cite{Sorv2014} describe y motiva este enfoque,
+\cite{Sorv2014} describen y motivan este enfoque,
 y~\cite{Koll2015} describe tres generaciones de herramientas
-designadas para soportar programación de personas novatas en ambientes orientados a objetos.
+designadas para apoyar a personas novatas para que programen en ambientes orientados a objetos.
 
 Introducir objetos temprano tiene algunos desafíos.
 \cite{Mill2016b} encontró que la mayoría de las personas novatas que usan Python\index{Python}
@@ -395,12 +395,12 @@ tenían problemas para entender \texttt{self}
 (que refiere al objeto actual):
 las personas lo omitieron en las definiciones de métodos,
 no lo usaron cuando hacían referencia a los atributos del objeto,
-o ambas.
+o tuvieron ambas dificultades.
 \cite{Rago2017} encontró algo similar en estudiantes de nivel secundario,
 y además encontró que docentes de secundaria usualmente tampoco tenían claro el concepto.
 En resumen,
-recomendamos que docentes \recommendation{comiencen con funciones en vez de objetos},
-es decir, que a las/los estudiantes no se les enseñe cómo definir clases
+recomendamos que, como docente, \recommendation{comiences con funciones en vez de objetos},
+es decir, que no les enseñes a tus estudiantes cómo definir clases
 hasta que comprendan las estructuras básicas de control y los tipos de datos.
 
 \subsection*{Declaración de tipos}
@@ -416,14 +416,14 @@ evita preguntas sobre qué métodos están disponibles y cómo usarlos.
 \subsection*{Nombrando variables}
 \index{variable naming}
 
-\cite{Kern1999} escribió,
-``A menudo se alienta a la gente que programa a usar nombres de variables largos independientemente del contexto.
+\cite{Kern1999} escribieron:
+``A menudo se alienta a quienes programan a usar nombres de variables largos independientemente del contexto.
 Esto es un error: la claridad a menudo se logra siendo breves.''
-Mucha gente que programa cree esto,
-pero \cite{Hofm2017} encontró que usar palabras completas en nombres de variables
+Muchas/os programadoras/es creen esto,
+pero \cite{Hofm2017} encontraron que usar palabras completas en nombres de variables
  condujo, en promedio, a una comprensión un 19\% más rápida en comparación con letras y abreviaturas.
 En contraste,
-\cite{Beni2017} encontró que el uso de nombres de variables de una sola letra no afectaba la capacidad de las personas principiantes para modificar el código.
+\cite{Beni2017} encontraron que el uso de nombres de variables de una sola letra no afectaba la capacidad de las personas principiantes de modificar el código.
 Esto puede deberse a que sus programas son más cortos que los de profesionales
 o porque algunos nombres de variables de una sola letra tienen tipos y significados implícitos.
 Por ejemplo,
@@ -433,26 +433,26 @@ mientras que \texttt{x}, \texttt{y} y \texttt{z} son números de punto flotante 
 más o menos equivalentemente.
 
 ¿Qué tan importante es esto?
-\cite{Bink2012} reportó que leer y comprender el código es fundamentalmente distinto de leer prosa:
+\cite{Bink2012} reportaron que leer y comprender el código es fundamentalmente distinto de leer prosa:
 ``{\ldots}la estructura más formal y la sintaxis del código fuente
-permite a la gente que programa, asimilar y comprender partes del código rápidamente independientemente del estilo.
-En particular{\ldots}las guías y los planes de programas juegan un papel importante en la comprensión.''
+permite a quienes programan asimilar y comprender partes del código rápidamente independientemente del estilo.
+En particular{\ldots}las guías y los planes de programación juegan un papel importante en la comprensión.''
 También encontró que a las/los desarrolladoras/es con experiencia no les afecta el estilo del identificador,
 entonces nuestra recomendación es utilizar un estilo coherente en todos los ejemplos.
 Dado que la mayoría de los lenguajes tienen guías de estilo
 (por ejemplo,\ \hreffoot{https://www.python.org/dev/peps/pep-0008/}{PEP 8} para Python)
 y herramientas para verificar que el código siga esas pautas,
 nuestra recomendación completa es
-\recommendation{usar herramientas para garantizar que todos los ejemplos de código se adhieran a un estilo consistente}.
+\recommendation{utiliza herramientas para garantizar que todos los ejemplos de código se adhieran a un estilo consistente}.
 
 \seclbl{¿Ayudan mejores mensajes de error?}{s:pck-error}
 \index{error messages}
 
 Los mensajes de error incomprensibles son una fuente importante de frustración para personas novatas
 (y también para personas experimentadas ).
-Por lo tanto, varias/os investigadoras/es han explorado si mejores mensajes de error ayudan a evitar esto.
+Por lo tanto, en varias investigaciones se exploró si mejores mensajes de error ayudan a evitar esto.
 Por ejemplo,
-\cite{Beck2016} reescribió algunos de los mensajes del compilador de Java para que en lugar de:
+\cite{Beck2016} reescribieron algunos de los mensajes del compilador de Java para que en lugar de:
 
 \begin{minted}{text}
 C:\stj\Hola.java:2: error: cannot find symbol
@@ -474,14 +474,14 @@ If ``string'' refers to a datatype, capitalize the 's'!
 Efectivamente,
 las personas novatas que recibieron estos mensajes repitieron menos errores y cometieron menos errores en general.
 
-\cite{Bari2017} fue más allá y usó seguimiento ocular para mostrar que
+\cite{Bari2017} fueron más allá y usaron seguimiento ocular para mostrar que
 a pesar de las quejas de las personas que escriben los compiladores,
 las personas realmente leen los mensajes de error---de hecho, pasan del 13 al 25\% de su tiempo haciendo eso.
 Sin embargo,
 leer mensajes de error resulta ser tan difícil como leer el código fuente,
 y la dificultad en leer los mensajes de error predice fuertemente el desempeño de la tarea.
-Por lo tanto, quienes enseñan
-\recommendation{deben mostrar a sus estudiantes cómo leer e interpretar mensajes de error}.
+Por lo tanto, al enseñar
+\recommendation{muéstrales a tus estudiantes cómo leer e interpretar mensajes de error}.
 \cite{Marc2011} tiene una rúbrica con respuestas a los mensajes de error que puede ser útil para calificar ese tipo de ejercicios.
 
 \subsection*{¿Ayuda la visualización?}
@@ -490,7 +490,7 @@ Por lo tanto, quienes enseñan
 Visualizar la ejecución de un programa es una idea siempre popular,
 y herramientas como el Tutor de Python en línea~\cite{Guo2013}
 y \hreffoot{http://latentflip.com/loupe/}{Loupe}
-(que muestra como funciona un bucle de eventos de JavaScript)
+(que muestra cómo funciona un bucle de eventos de JavaScript)
 son útiles para enseñar.
 Sin embargo,
 las personas aprenden más al construir visualizaciones
@@ -498,7 +498,7 @@ que al ver visualizaciones construidas por otras personas \cite{Stas1998,Ceti201
 entonces, ¿las visualizaciones realmente ayudan al aprendizaje?
 
 Para responder esto,
-\cite{Cunn2017} replicó un estudio previo sobre los tipos de esquemas que realizan las/los estudiantes cuando rastrean la ejecución del código.
+\cite{Cunn2017} replicaron un estudio previo sobre los tipos de esquemas que realizan las/los estudiantes cuando rastrean la ejecución del código.
 Encontraron que no hacer esquemas se correlaciona con un menor éxito,
 mientras que el seguimiento de los cambios de valor de una variable escribiendo los nuevos valores cerca de su nombre
 a medida que cambian fue la estrategia más efectiva.
@@ -513,9 +513,9 @@ Nuestra recomendación es, por lo tanto, \recommendation{enseña a rastrear los 
 \begin{aside}{Diagramas de flujo}\index{flowcharts}
   Un hallazgo que a menudo se pasa por alto sobre la visualización es que
   las personas entienden mejor los diagramas de flujo que el pseudocódigo \emph{si ambos están igualmente bien estructurados}~\cite{Scan1989}.
-  Trabajos anteriores que muestran que el pseudocódigo supera a los diagramas de flujo usaron pseudocódigo estructurado pero diagramas de flujo desordenado;
-  pero cuando se nivelaba el campo de juego,
-  a las personas novatas les iba mejor con la representación gráfica.
+  Los estudios previos que señalaban que el pseudocódigo superaba a los diagramas de flujo usaron pseudocódigo estructurado pero diagramas de flujo desordenados:
+  cuando se niveló el campo de juego,
+  se observó que a las personas novatas les fue mejor con la representación gráfica.
 \end{aside}
 
 \seclbl{¿Qué más podemos hacer para ayudar?}{s:pck-help}
@@ -524,15 +524,15 @@ Nuestra recomendación es, por lo tanto, \recommendation{enseña a rastrear los 
 Señalan que hay muchas razones para tomar sus conclusiones con cautela:
 las prácticas de enseñanza previas al cambio rara vez se establecen claramente,
 la calidad del cambio no es juzgada,
-y solo el 8.3\% de los estudios reportaron resultados negativos;
-entonces, o hay un sesgo al reportar resultados,
+y solo el 8.3\% de los estudios reportaron resultados negativos. 
+Entonces, o hay un sesgo al reportar resultados,
 o la forma en la que enseñamos en este momento es la peor posible y cualquier cosa sería una mejora.
-Y como muchos otros estudios discutidos en este capítulo,
+Como muchos otros estudios discutidos en este capítulo,
 en este trabajo sólo estaban observando clases universitarias,
 por lo que sus hallazgos pueden no ser generalizables a otros grupos.
 
 Con esas advertencias en mente,
-encontraron diez cosas que las/dos docentes puede hacer para mejorar los resultados (\figref{f:pck-interventions}):
+los autores encontraron diez cosas que las/dos docentes puede hacer para mejorar los resultados (\figref{f:pck-interventions}):
 
 \begin{description}
 
@@ -549,7 +549,7 @@ encontraron diez cosas que las/dos docentes puede hacer para mejorar los resulta
   Creación de un curso preliminar a tomar antes del curso introductorio de programación;
   podría organizarse solo para algunas personas (por ejemplo, si están en riesgo).
 
-\item[Cómo jugando:]
+\item[Temática de juego:]
   Una componente de juego fue introducida en el curso.
 
 \item[Esquema de calificación:]
@@ -563,7 +563,7 @@ encontraron diez cosas que las/dos docentes puede hacer para mejorar los resulta
   Actividades que usen explícitamente el uso de recursos multimedia (\chapref{s:motivation}).
 
 \item[Apoyo de colegas:]
-  El apoyo de pares en forma de parejas, grupos, mentores contratados o tutoras/es.
+  El apoyo de pares en forma de parejas, grupos, mentores contratados o tutorías.
 
 \item[Otro apoyo:]
   Un término general para todas las actividades de apoyo,
@@ -574,8 +574,8 @@ encontraron diez cosas que las/dos docentes puede hacer para mejorar los resulta
 \figimg{figures/interventions-scaled.png}{Efectividad de las intervenciones}{f:pck-interventions}
 
 Esta lista destaca la importancia del aprendizaje cooperativo.
-\cite{Beck2013} analizó esto específicamente durante tres años académicos en cursos a cargo dos docentes diferentes
-y encontró beneficios significativos en general y para muchos subgrupos.
+\cite{Beck2013} analizaron esto específicamente durante tres años académicos en cursos a cargo dos docentes diferentes
+y encontraron beneficios significativos en general y para muchos subgrupos.
 Las personas que cooperaron obtuvieron calificaciones más altas
 y dejaron menos preguntas en blanco en el examen final,
 lo que indica una mayor autoeficacia y disposición para depurar cosas.
@@ -585,18 +585,18 @@ lo que indica una mayor autoeficacia y disposición para depurar cosas.
   hacer que las personas novatas trabajen en ejercicios de creatividad computacional mejora sus calificaciones en varios niveles~\cite{Shel2017}.
   Un ejercicio típico es describir un objeto cotidiano (como un clip o un cepillo de dientes)
   en términos de sus entradas, salidas y funciones.
-  Este tipo de enseñanza a veces se le llama \grefdex{g:cs-unplugged}{desconectado}{CS unplugged};
+  Este tipo de enseñanza a veces se es llamada \grefdex{g:cs-unplugged}{desconectado}{CS unplugged};
   La página web \hreffoot{https://csunplugged.org/en/}{CS~Unplugged} tiene lecciones y ejercicios para esto.
 \end{aside}
 
 \seclbl{¿Qué sigue?}{s:pck-final}
 
 Para aquellas personas que quieran profundizar,
-\cite{Finc2019} es un completo resumen de CER,
+\cite{Finc2019} es un completo resumen de investigación sobre educación en informática y
 \cite{Ihan2016} resume los métodos que estos estudios usan más frecuentemente.
 Espero que algún día tengamos catálogos como~\cite{Ojos2015}
 y más materiales para capacitar docentes como~\cite{Hazz2014,Guzd2015a,Sent2018}
-para ayudarnos a todas y todos a enseñar mejor.
+para ayudarnos a enseñar mejor.
 
 La mayor parte de la investigación mencionada en este capítulo fue financiada con fondos públicos
 pero tenemos que pagar para leerla:
@@ -638,26 +638,25 @@ Estos errores comunes corresponden a una lista más larga en ~\cite{Sirk2012}:
 \noindent
 Escribe un ejercicio para chequear que tus estudiantes \emph{no} están cometiendo cada uno de estos errores.
 
-\exercise{Código desarmado}{en parejas}{15'}
+\exercise{Código desarmado}{parejas}{15'}
 
-\cite{Chen2017} describe ejercicios en los que las/los estudiantes reconstruyen el código que ha sido desarmado
+\cite{Chen2017} describen ejercicios en los que las/los estudiantes reconstruyen el código que ha sido desarmado
 al eliminar comentarios,
 borrar o reemplazar líneas de código,
-moviendo líneas,
+al mover líneas,
 etc.
 El rendimiento en estos ejercicios se correlaciona fuertemente con el rendimiento en las evaluaciones
-donde las personas deben escribir código,
+en las que las personas deben escribir código,
 pero estas preguntas requieren menos trabajo para evaluar.
-Toma la solución de un ejercicio de programación que hayas creado en el pasado,
-desármalo de dos maneras distintas,
-intercambia el ejercicio con alguien más,
-y mira cuanto tiempo le lleva a cada persona responder correctamente tu problema.
+Toma la solución de un ejercicio de programación que hayas creado en el pasado y desármalo de dos maneras distintas.
+Intercambia el ejercicio con tu pareja.
+Analicen cuánto tiempo les lleva responder correctamente los problemas elaborados por la otra persona.
 
-\exercise{El problema de la lluvia}{en parejas}{10'}
+\exercise{El problema de la lluvia}{parejas}{10'}
 
 \cite{Solo1986} presentó el problema de la lluvia,
 que se ha usado en muchos estudios posteriores sobre programación~\cite{Fisl2014,Simo2013,Sepp2015}.
-Escribir un programa que repetidamente lee números enteros positivos hasta que llega a 99999.
+Escribe un programa que repetidamente lea números enteros positivos hasta que llega a 99999.
 Después de llegar a 99999,
 el programa imprime el promedio de esos números leídos.
 
@@ -667,12 +666,12 @@ el programa imprime el promedio de esos números leídos.
   Resuelve el problema de la lluvia en el lenguaje de programación que prefieras.
 
 \item
-  Compara tu solución con las de tu colega.
+  Compara tu solución con la de tu pareja.
   ¿Qué hace tu programa que no hace el de tu colega y viceversa?
 
 \end{enumerate}
 
-\exercise{Roles de variables}{en parejas}{15'}
+\exercise{Roles de variables}{parejas}{15'}
 
 \cite{Kuit2004,Byck2005,Saja2006} presentaron un conjunto de patrones de una sola variable
 que encuentro muy útil en la enseñanza de personas novatas:
@@ -716,7 +715,7 @@ que encuentro muy útil en la enseñanza de personas novatas:
 \end{description}
 
 Elige un programa de 5 a 15 líneas y clasifica sus variables usando estas categorías.
-Compara tus clasificaciones con tu colega.
+Compara tus clasificaciones con tu pareja.
 En los casos en los que no estuvieron de acuerdo,
 ¿entendieron el punto de vista de la otra persona?
 
@@ -746,10 +745,10 @@ elige una sección (por ejemplo, estructura de datos o funciones) y revisa la li
 
 \exercise{¿Qué es lo que más te importa?}{toda la clase}{15'}
 
-\cite{Denn2019} le pidió a personas que propongan y califiquen varias preguntas de CER,
-y encontraron que no había superposición entre las preguntas que más les importaban a los investigadores
-a las que les interesaba a quienes no investigaban.
-Las preguntas favoritas de investigadores fueron:
+\cite{Denn2019} les pidieron a varias personas que propongan y califiquen preguntas de investigación sobre educación en informática.
+Encontraron que no había superposición entre las preguntas que más les importaban a las/los investigadoras/es
+y las que les interesaban a quienes no investigaban.
+Las preguntas favoritas de las/los investigadoras/es fueron:
 
 \begin{enumerate}
 

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -785,7 +785,7 @@ Mientras que las preguntas más importantes para las personas que no investigan 
   ¿Cómo y cuándo es mejor dar retroalimentación a las/los estudiantes sobre su código para mejorar el aprendizaje?
 
 \item
-  ¿Qué tipo de ejercicios de programación son más efectivos al enseñar a estudiantes de iencias de la Computación?
+  ¿Qué tipo de ejercicios de programación son más efectivos al enseñar a estudiantes de Ciencias de la Computación?
 
 \item
   ¿Cuáles son los méritos relativos del aprendizaje basado en proyectos, las clases y el aprendizaje activo, para estudiantes de computación?

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -97,7 +97,7 @@ con y sin experiencia previa en programación en CS1 y CS2 (ver más abajo).
 Encontraron que personas novatas con experiencia previa superaron a personas sin experiencia en un 10\% en CS1,
 pero esas diferencias desaparecieron hacia el final de CS2.
 También encontraron que las mujeres con experiencia previa superaron a sus pares masculinos en todas las áreas,
-pero siempre tenían menos confianza en sus habilidades. (\secref{s:motivation-inclusivity}).
+pero siempre tenían menos confianza en sus habilidades (\secref{s:motivation-inclusivity}).
 
 En cuanto a estudios sobre cuánto aprenden las personas novatas,
 \cite{McCr2001} presentaron un estudio internacional en múltiples espacios que luego fue replicado por~\cite{Utti2013}.

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -116,7 +116,7 @@ de tal manera que se puedan comparar a través del tiempo para que puedas saber 
 
 \chapref{s:models} explicó por qué aclarar los conceptos erróneos a las personas novatas es tan importante como enseñarles
 estrategias para resolver problemas.
-La mayor confusión de las personas novatas ---a veces llamada el ``superbug'' en programación ---es\index{superbug}
+La mayor confusión de las personas novatas ---a veces llamada el \emph{``superbug''} o ``supererror'' en programación ---es\index{superbug}
 la creencia de que las computadoras entienden lo que las personas quieren decir de la misma manera que cualquier ser humano lo haría~\cite{Pea1986}.
 Nuestra segunda recomendación es entonces \recommendation{enseña a las personas novatas que las computadoras no entienden los programas},
 es decir, que llamar a una variable ``precio'' no garantiza que su valor sea realmente un precio.

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -52,7 +52,8 @@ Pero dado que las/los docentes reales que enseñan en aulas reales tienen que to
   la investigación sobre educación en informática tiene jerga.
   \gref{g:cs1}{CS1} refiere a un curso introductorio de un semestre de duración, donde los estudiantes aprenden variables, bucles y funciones por primera vez, mientras que \gref{g:cs2}{CS2} refiere a un segundo curso que cubre las estructuras de datos básicas como pilas y colas, 
   y \gref{g:cs0}{CS0} se refiere a un curso introductorio para personas sin experiencia previa y que no tienen intención de continuar con computación de inmediato.
-  Las definiciones completas de estos términos se encuentran en los \hreffoot{https://www.acm.org/education/curricula-recommendations}{lineamientos del programa ACM}.
+  Las definiciones completas de estos términos se encuentran en los \hreffoot{https://www.acm.org/education/curricula-recommendations}{lineamientos del programa \emph{ACM} (
+Association for Computing Machinery, por sus siglas en inglés)}.
 \end{aside}
 
 \seclbl{¿Qué les estamos enseñando ahora?}{s:pck-now}

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -229,7 +229,7 @@ Un trabajo reciente mostró la efectividad de enseñar cuatro habilidades distin
 \end{longtable}
 
 Por lo tanto, nuestras siguientes recomendaciones son:
-\recommendation{haz que tus estudiantes lean código, luego lo modifiquen, luego lo escriban} y además  \recommendation{preséntales explícitamente patrones explícitos y haz que practiquen usándolos}.
+\recommendation{haz que tus estudiantes lean código, luego lo modifiquen, luego lo escriban} y además  \recommendation{preséntales explícitamente patrones comunes y haz que practiquen usándolos}.
 \cite{Mull2007b} es uno de los tantos estudios que muestran los beneficios de enseñar patrones comunes de manera explícita. Descomponer los problemas
 en patrones comunes crea oportunidades naturales para crear y etiquetar sub-objetivos~\cite{Marg2012,Marg2016}.\index{labeled subgoals}
 

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -740,7 +740,7 @@ El sitio \hreffoot{http://www.pd4cs.org/}{Desarrollo Profesional para la Enseña
 incluye \hreffoot{http://www.pd4cs.org/mc-index/}{una lista detallada de conceptos erróneos de estudiantes y ejercicios}.
 Trabajando en grupos pequeños,
 elige una sección (por ejemplo, estructura de datos o funciones) y revisa la lista.
-¿Cuáles de estoss conceptos erróneos recuerdas haber tenido cuando eras estudiante?
+¿Cuáles de estos conceptos erróneos recuerdas haber tenido cuando eras estudiante?
 ¿Cuáles tienes todavía?
 ¿Cuáles has visto en tus estudiantes?
 

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -271,7 +271,7 @@ Enseñar a principiantes cómo depurar errores también puede ayudar a que las c
 \cite{Alqa2017} encontró que estudiantes con mayor experiencia resolvieron problemas de depuración de errores significativamente más rápido,
 pero los tiempos variaron ampliamente:
 4--10 minutos fue el rango típico para ejercicios individuales,
-lo cual significa que algunas/os estudiantes necesitan 2--3 más tiempo que otros para resolver el mismo ejercicio.
+lo cual significa que algunas/os estudiantes necesitan entre 2 y 3 veces más tiempo que otras/os para resolver el mismo ejercicio.
 Para ayudar a que el progreso de todo el grupo sea más uniforme,
 es conveniente enseñarles a quienes resuelven los ejercicios más lentamente qué están haciendo las personas más rápidas.
 

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -311,7 +311,7 @@ quienes examinaron todos los errores en los envíos de códigos realizados por p
 y a su vez identificaron aquellos errores detectados por el conjunto de pruebas de personas novatas.
 En este trabajo se encontró que las pruebas de personas novatas solo detectaban un promedio de 13,6\% de los errores presentes en la totalidad de los programas.
 Además,
-el 90\% de las pruebas de las personas novatos fueron muy parecidas,
+el 90\% de las pruebas de las personas novatas fueron muy parecidas,
 lo que indica que las personas novatas escriben pruebas principalmente para confirmar que el código está haciendo lo que se supone que debe hacer
 en lugar de encontrar situaciones en las que no ocurre esto.
 

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -35,7 +35,7 @@ se requiere cierta precaución al interpretar los resultados:
   simplemente no sabemos tanto sobre cómo aprender a programar como sí sabemos sobre aprender a leer, jugar un deporte o resolver cálculos simples.
  
 \item[La mayoría de las personas en estos estudios
-  viven en sociedades occidentales, democráticas, industrializadas y con alto nivel de riqueza y educación], tal como señala ~\cite{Henr2010}.
+  viven en sociedades occidentales, democráticas, industrializadas y con alto nivel de riqueza y educación] y se los denomina WEIRD\index{WEIRD} por \emph{Western, Education, Industrialized, Rich, and Democratic en inglés}, tal como señala ~\cite{Henr2010}.
   Además,
   son principalmente jóvenes que estudian en instituciones educativas, ya que es la población a la que la mayoría de las personas que investigan tienen fácil acceso.
   Sabemos mucho menos sobre adultos, grupos marginados y estudiantes en ambientes educativos flexibles (estudiantes free-range), así como sobre \grefdex{g:end-user-programmer}{usuarias/os finales programadoras/es},

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -14,7 +14,7 @@ Cada docente necesita tres cosas:
 \item[\gref{g:pedagogical-content-knowledge}{conocimiento de la pedagogía del contenido}],
   que es el conocimiento específico acerca de cómo enseñar un concepto particular a un público en particular.
   En informática,
-  el conocimiento de la pedagogía del contenido incluye qué ejemplos usar cuando se enseña, cómo se incluyen parámetros en una función o qué concepciones erróneas sobre etiquetas HTML anidadas son los más comunes.
+  el conocimiento de la pedagogía del contenido incluye qué ejemplos usar cuando se enseña, cómo se incluyen parámetros en una función o qué conceptos erróneos sobre etiquetas HTML anidadas son los más comunes.
 \end{description}
 
 Podemos agregar conocimiento técnico a este conjunto~\cite{Koeh2013},
@@ -111,16 +111,16 @@ pero de cualquier manera,
 nuestra primera recomendación es \recommendation{mide y haz un seguimiento de los resultados}
 de tal manera que se puedan comparar a través del tiempo para que puedas saber si tus lecciones se están volviendo más o menos efectivas.
 
-\seclbl{¿Qué concepciones erróneas tienen las personas novatas?}{s:pck-misunderstand}
+\seclbl{¿Qué conceptos erróneos tienen las personas novatas?}{s:pck-misunderstand}
 
-\chapref{s:models} explicó por qué aclarar las concepciones erróneas a las personas novatas es tan importante como enseñarles
+\chapref{s:models} explicó por qué aclarar los conceptos erróneos a las personas novatas es tan importante como enseñarles
 estrategias para resolver problemas.
 La mayor confusión de las personas novatas ---a veces llamada el ``superbug'' en programación ---es\index{superbug}
 la creencia de que las computadoras entienden lo que las personas quieren decir de la misma manera que cualquier ser humano lo haría~\cite{Pea1986}.
 Nuestra segunda recomendación es entonces \recommendation{enseña a las personas novatas que las computadoras no entienden los programas},
 es decir, que llamar a una variable ``precio'' no garantiza que su valor sea realmente un precio.
 
-\cite{Sorv2018} muestra más de cuarenta concepciones erróneas que las/los docentes también pueden intentar aclarar,
+\cite{Sorv2018} muestra más de cuarenta conceptos erróneos que las/los docentes también pueden intentar aclarar,
 muchos de las cuales también se discuten en el estudio de~\cite{Qian2017}.
 Una es la creencia de que las variables en los programas funcionan de la misma manera que en planillas de cálculo,
 es decir, que luego de ejecutar:
@@ -356,7 +356,7 @@ las autoras plantean la hipótesis de que las/los usuarias/os pueden estar utili
 para hacer un seguimiento de las partes del código que no quieren eliminar (todavía).
 Otros ejemplos son~\cite{Grov2017,Mlad2017},
 que estudiaron a personas novatas aprendiendo sobre bucles en Scratch, Logo y Python.\index{Scratch}\index{Python}
-Encontraron que las ideas erróneas sobre bucles se minimizan cuando se usa un lenguaje basado en bloques
+Encontraron que los conceptos erróneos sobre bucles se minimizan cuando se usa un lenguaje basado en bloques
 en lugar de un lenguaje basado en texto.
 Además,
 a medida que las tareas se vuelven más complejas (como el uso de bucles anidados)
@@ -609,10 +609,10 @@ por favor ayuda a que ese día se acerque publicando tu trabajo en lugares de ac
 
 \seclbl{Ejercicios}{s:pck-exercises}
 
-\exercise{Concepciones erróneas de tus estudiantes}{grupos pequeños}{15'}
+\exercise{Conceptos erróneos de tus estudiantes}{grupos pequeños}{15'}
 
 Trabajando en grupos pequeños,
-vuelvan a leer la \secref{s:pck-misunderstand} y escriban una lista de concepciones erróneas que piensan que pueden tener sus estudiantes.
+vuelvan a leer la \secref{s:pck-misunderstand} y escriban una lista de conceptos erróneos que piensan que pueden tener sus estudiantes.
 ¿Qué tan específicos son?
 ¿Cómo verificarían que tan precisa es su lista?
 
@@ -733,13 +733,13 @@ Mira la lista de intervenciones desarrolladas por~\cite{Viha2014} (\secref{s:pck
 ¿Cuáles podrías agregar fácilmente?
 ¿Cuáles son irrelevantes?
 
-\exercise{Concepciones erróneas y desafíos}{grupos pequeños}{15'}
+\exercise{Conceptos erróneos y desafíos}{grupos pequeños}{15'}
 
 El sitio \hreffoot{http://www.pd4cs.org/}{Desarrollo Profesional para la Enseñanza de Principios  de CS}
-incluye \hreffoot{http://www.pd4cs.org/mc-index/}{una lista detallada de concepciones erróneas de estudiantes y ejercicios}.
+incluye \hreffoot{http://www.pd4cs.org/mc-index/}{una lista detallada de conceptos erróneos de estudiantes y ejercicios}.
 Trabajando en grupos pequeños,
 elige una sección (por ejemplo, estructura de datos o funciones) y revisa la lista.
-¿Cuáles de estas concepciones erróneas recuerdas haber tenido cuando eras estudiante?
+¿Cuáles de estoss conceptos erróneos recuerdas haber tenido cuando eras estudiante?
 ¿Cuáles tienes todavía?
 ¿Cuáles has visto en tus estudiantes?
 

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -4,23 +4,22 @@ Cada docente necesita tres cosas:
 
 \begin{description}
 
-\item[\gref{g:content-knowledge}{conocimiento del contenido}]
+\item[\gref{g:content-knowledge}{conocimiento del contenido}],
   por ejemplo, como programar;
 
-\item[\gref{g:general-pedagogical-knowledge}{conocimiento general de pedagogía}]
+\item[\gref{g:general-pedagogical-knowledge}{conocimiento general de pedagogía}],
   por ejemplo, comprensión de la psicología del aprendizaje;
   y
 
-\item[\gref{g:pedagogical-content-knowledge}{conocimiento de la pedagogía del contenido}]
-  (PCK por Pedagogical Content Knowledge en inglés),
-  que es el conocimiento específico de cómo enseñar un concepto particular a una audiencia en particular.
+\item[\gref{g:pedagogical-content-knowledge}{conocimiento de la pedagogía del contenido}],
+  que es el conocimiento específico acerca de cómo enseñar un concepto particular a un público en particular.
   En informática,
-  PCK incluye cosas tales como qué ejemplos usar cuando se enseña, como se incluyen parámetros en una función o qué conceptos erróneos son los más comunes sobre etiquetas HTML anidadas.
+  el conocimiento de la pedagogía del contenido incluye qué ejemplos usar cuando se enseña, cómo se incluyen parámetros en una función o qué concepciones erróneas sobre etiquetas HTML anidadas son los más comunes.
 \end{description}
 
 Podemos agregar conocimiento técnico a este conjunto~\cite{Koeh2013},
-pero eso no cambia el punto clave: no es suficiente saber sobre el tema y como enseñar---tienes que saber cómo enseñar ese tema en particular~\cite{Maye2004}.
-Este capítulo resume algunos resultados de investigaciones sobre enseñanza de informática para añadir a tu colección de PCK.
+pero eso no cambia el punto clave: no es suficiente saber sobre el tema y cómo enseñar---tienes que saber cómo enseñar ese tema en particular~\cite{Maye2004}.
+Este capítulo resume algunos resultados de investigaciones sobre enseñanza de informática para añadir a tu colección sobre el conocimiento de la pedagogía del contenido.
 
 Como con toda investigación,
 se requiere cierta precaución al interpretar los resultados:
@@ -28,52 +27,52 @@ se requiere cierta precaución al interpretar los resultados:
 \begin{description}
 
 \item[Las teorías cambian a medida que se obtienen más datos.]
-  La investigación en educación en informática (CER, por Computing education research en inglés) es una disciplina nueva:\index{computing education research}
-  la Sociedad Americana de Educación en Ingeniería fue fundada en 1893 y el Consejo Nacional de Profesores de Matemática en 1920, pero la Asociación de Profesores de Informática no se creó hasta 2005.
+  La investigación sobre educación en informática es una disciplina nueva:\index{computing education research}
+  la Sociedad Americana de Educación en Ingeniería fue fundada en 1893 y el Consejo Nacional de Docentes de Matemática en 1920, pero la Asociación de Docentes de Informática no se creó hasta 2005.
   Mientras que existe un flujo constante de nuevo conocimiento en conferencias como \hreffoot{http://sigcse.org/}{SIGCSE},
-  \hreffoot{http://iticse.acm.org/}{ITiCSE},
-  y \hreffoot{https://icer.hosting.acm.org}{ICER},
-  simplemente no sabemos tanto sobre como aprender a programar como sí sabemos sobre aprender a leer, jugar un deporte o resolver cálculos simples.
+  \hreffoot{http://iticse.acm.org/}{ITiCSE}
+  e \hreffoot{https://icer.hosting.acm.org}{ICER},
+  simplemente no sabemos tanto sobre cómo aprender a programar como sí sabemos sobre aprender a leer, jugar un deporte o resolver cálculos simples.
  
-\item[La mayoría de las personas en estos estudios son WEIRD:]\index{WEIRD}
-  viven en sociedades occidentales, democráticas, industrializadas y con alto nivel de riqueza y educación (WEIRD por Western, Education, Industrialized, Rich, and Democratic en inglés)~\cite{Henr2010}.
+\item[La mayoría de las personas en estos estudios
+  viven en sociedades occidentales, democráticas, industrializadas y con alto nivel de riqueza y educación], tal como señala ~\cite{Henr2010}.
   Además,
-  son principalmente jóvenes en contextos formales, ya que es la población a la que la mayoría de las personas que investigan tienen fácil acceso.
-  Sabemos mucho menos sobre adultos, grupos marginados y estudiantes en contextos no formales o \grefdex{g:end-user-programmer}{usuario final programador}{usuario final programador},
+  son principalmente jóvenes que estudian en instituciones educativas, ya que es la población a la que la mayoría de las personas que investigan tienen fácil acceso.
+  Sabemos mucho menos sobre adultos, grupos marginados y estudiantes en ambientes educativos flexibles (estudiantes free-range), así como sobre \grefdex{g:end-user-programmer}{usuarias/os finales programadoras/es}{usuario final programador},
   aún cuando son la mayoría.
 
 \end{description}
 
 Si esto fuera un ensayo académico, empezaría la mayoría de oraciones con frases como,
 ``Algunas investigaciones parece indicar que{\ldots}''
-Pero dado que los y las docentes en las aulas tienen que tomar decisiones independientemente de si las investigaciones tienen respuestas claras o no, este capítulo presenta las mejores conjeturas prácticas en lugar de sutiles posibilidades.
+Pero dado que las/los docentes reales que enseñan en aulas reales tienen que tomar decisiones independientemente de si las investigaciones tienen respuestas claras o no, este capítulo presenta las mejores conjeturas prácticas en lugar de sutiles posibilidades.
 
 \begin{aside}{Jerga}
   Como cualquier especialidad,
-  CER tiene jerga.
+  la investigación sobre educación en informárica tiene jerga.
   \gref{g:cs1}{CS1} refiere a un curso introductorio de un semestre de duración, donde los estudiantes aprenden variables, bucles y funciones por primera vez, mientras que \gref{g:cs2}{CS2} refiere a un segundo curso que cubre las estructuras de datos básicas como pilas y colas, 
   y \gref{g:cs0}{CS0} se refiere a un curso introductorio para personas sin experiencia previa y que no tienen intención de continuar con computación de inmediato.
-  Las definiciones completas de estos términos se encuentran en \hreffoot{https://www.acm.org/education/curricula-recommendations}{Lineamientos del programa ACM}.
+  Las definiciones completas de estos términos se encuentran en los \hreffoot{https://www.acm.org/education/curricula-recommendations}{lineamientos del programa ACM}.
 \end{aside}
 
 \seclbl{¿Qué les estamos enseñando ahora?}{s:pck-now}
 
-Se sabe muy poco sobre qué enseñan en coding bootcamps e iniciativas no formales, en parte porque muchas personas son reticentes a compartir los programas.
+Se sabe muy poco sobre qué se enseña en entrenamientos de programación intensivo e iniciativas free-range, en parte porque muchas personas son reticentes a compartir los programas.
 Sabemos más sobre lo que  se enseña en instituciones~\cite{Luxt2017}:
 
 \begin{longtable}{llll}
 \textbf{Temas}            & \textbf{\%}    & \textbf{Temas}        & \textbf{\%} \\
 Proceso de programación         & 87\%        & Tipos de datos                & 23\% \\
-Pensamiento abstracto para programación    & 63\%        & Entrada /Salida                  & 17\% \\
+Pensamiento abstracto para programación    & 63\%        & Entrada/Salida                  & 17\% \\
 Estructuras de datos              & 40\%        & Librerías                     & 15\% \\
-Conceptos orientados a objetos        & 36\%        & Variables y Asignación       & 14\% \\
+Conceptos orientados a objetos        & 36\%        & Variables y asignación       & 14\% \\
 Estructuras de control              & 33\%        & Recursión             & 10\% \\
-Operaciones y Funciones         & 26\%        & Punteros y administración de memoria    &  5\%
+Operaciones y funciones         & 26\%        & Punteros y administración de memoria    &  5\%
 \end{longtable}
 
 Títulos de temas de alto nivel como estos pueden esconder una gran cantidad de fallas.
 Un resultado más tangible surge de \cite{Rich2017},
-donde revisa cien artículos para encontrar trayectorias de aprendizaje para clases de computación en escuelas primarias y secundarias.
+quienes revisaron cien artículos y encontraron trayectorias de aprendizaje para clases de computación en escuelas primarias y secundarias.
 Sus resultados para la secuenciación, la repetición y los condicionales son esencialmente mapas conceptuales colectivos
 que combinan y racionalizan el pensamiento implícito y explícito de gran cantidad de docentes.
 (\figref{f:pck-trajectory}).
@@ -84,44 +83,44 @@ que combinan y racionalizan el pensamiento implícito y explícito de gran canti
 
 \seclbl{¿Cuánto están aprendiendo?}{s:pck-learning}
 
-Puede haber un mundo de distancia entre lo que enseñan las/los docentes y cuánto aprenden las personas.
-Para explorar lo último, debemos usar otras medidas o hacer estudios directos.
+Puede haber un mundo de distancia entre lo que enseñan las/los docentes y cuánto aprenden sus estudiantes.
+Para explorar cuánto se aprende, debemos usar otras medidas o hacer estudios directos.
 Tomando el primer enfoque, aproximadamente dos tercios de las/los estudiantes de nivel superior aprueban su primer curso de informática,
 con algunas variaciones dependiendo del tamaño de la clase,
 pero sin diferencias significativas a lo largo del tiempo o basadas en el lenguaje~\cite{Benn2007a,Wats2014}.
 
 ¿Cómo afecta la experiencia previa a estos resultados?\index{effect of prior experience}
 Para responder esto,
-\cite{Wilc2018} compara el desempeño y la confianza de personas novatas
+\cite{Wilc2018} compararon el desempeño y la confianza de personas novatas
 con y sin experiencia previa en programación en CS1 y CS2 (ver más abajo).
 Encontraron que personas novatas con experiencia previa superaron a personas sin experiencia en un 10\% en CS1,
 pero esas diferencias desaparecieron hacia el final de CS2.
 También encontraron que las mujeres con experiencia previa superaron a sus pares masculinos en todas las áreas,
 pero siempre tenían menos confianza en sus habilidades. (\secref{s:motivation-inclusivity}).
 
-En cuanto a estudios sobre cuanto aprenden las personas novatas,
-\cite{McCr2001} presenta un estudio internacional en múltiples espacios que luego fue replicado por~\cite{Utti2013}.
+En cuanto a estudios sobre cuánto aprenden las personas novatas,
+\cite{McCr2001} presentaron un estudio internacional en múltiples espacios que luego fue replicado por~\cite{Utti2013}.
 De acuerdo al primer estudio,
 ``{\ldots}los decepcionantes resultados sugieren que
 muchas/os estudiantes no saben cómo programar al final de los cursos introductorios''.
 Más específicamente,
 ``Para una muestra combinada de 216 estudiantes de cuatro universidades,
-la puntuación media fue de 22,89 sobre 110 puntos en los criterios generales de evaluación desarrollados para este estudio''
+la puntuación media fue de 22,89 sobre 110 puntos en los criterios generales de evaluación desarrollados para este estudio.''
 Este resultado puede hablar tanto de las expectativas de profesores como de la habilidad de las/los estudiantes,
 pero de cualquier manera,
 nuestra primera recomendación es \recommendation{medir y hacer un seguimiento de los resultados}
 de tal manera que se puedan comparar a través del tiempo para que puedas saber si tus lecciones se están volviendo más o menos efectivas.
 
-\seclbl{¿Qué conceptos erróneos tienen las personas novatas?}{s:pck-misunderstand}
+\seclbl{¿Qué concepciones erróneas tienen las personas novatas?}{s:pck-misunderstand}
 
-\chapref{s:models} explicó por qué aclarar los conceptos erróneos a las personas novatas es tan importante, como enseñarles
+\chapref{s:models} explicó por qué aclarar las concepciones erróneas a las personas novatas es tan importante como enseñarles
 estrategias para resolver problemas.
 La mayor confusión de las personas novatas ---a veces llamada el ``superbug'' en programación ---es\index{superbug}
 la creencia de que las computadoras entienden lo que las personas quieren decir de la misma manera que cualquier ser humano lo haría~\cite{Pea1986}.
 Nuestra segunda recomendación es entonces \recommendation{enseñar a las personas novatas que las computadoras no entienden los programas},
 es decir, que llamar a una variable ``precio'' no garantiza que su valor sea realmente un precio.
 
-\cite{Sorv2018}  muestra más de cuarenta conceptos erróneos que docentes también pueden intentar aclarar,
+\cite{Sorv2018}  muestra más de cuarenta concepciones erróneas que las/los docentes también pueden intentar aclarar,
 muchos de las cuales también se discuten en el estudio de~\cite{Qian2017}.
 Una es la creencia de que las variables en los programas funcionan de la misma manera que en planillas de cálculo,
 es decir, que luego de ejecutar:
@@ -610,10 +609,10 @@ por favor ayuda a que ese día se acerque publicando tu trabajo en lugares de ac
 
 \seclbl{Ejercicios}{s:pck-exercises}
 
-\exercise{Conceptos erróneos de tus estudiantes}{grupos pequeños}{15'}
+\exercise{Concepciones erróneas de tus estudiantes}{grupos pequeños}{15'}
 
 Trabajando en grupos pequeños,
-vuelvan a leer la \secref{s:pck-misunderstand} y escriban una lista de conceptos erróneos que piensan que pueden tener sus estudiantes.
+vuelvan a leer la \secref{s:pck-misunderstand} y escriban una lista de concepciones erróneas que piensan que pueden tener sus estudiantes.
 ¿Qué tan específicos son?
 ¿Cómo verificarían que tan precisa es su lista?
 
@@ -735,13 +734,13 @@ Mira la lista de intervenciones desarrolladas por~\cite{Viha2014} (\secref{s:pck
 ¿Cuáles podrías agregar fácilmente?
 ¿Cuáles son irrelevantes?
 
-\exercise{Conceptos erróneos y desafíos}{grupos pequeños}{15'}
+\exercise{Concepciones erróneas y desafíos}{grupos pequeños}{15'}
 
 El sitio \hreffoot{http://www.pd4cs.org/}{Desarrollo Profesional para la Enseñanza de Principios  de CS}
-incluye \hreffoot{http://www.pd4cs.org/mc-index/}{una lista detallada de conceptos erróneos de estudiantes y ejercicios}.
+incluye \hreffoot{http://www.pd4cs.org/mc-index/}{una lista detallada de concepciones erróneas de estudiantes y ejercicios}.
 Trabajando en grupos pequeños,
 elige una sección (por ejemplo, estructura de datos o funciones) y revisa la lista.
-¿Cuáles de estos conceptos erróneos recuerdas haber tenido cuando eras estudiante?
+¿Cuáles de estas concepciones erróneas recuerdas haber tenido cuando eras estudiante?
 ¿Cuáles tienes todavía?
 ¿Cuáles has visto en tus estudiantes?
 

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -108,7 +108,7 @@ Más específicamente,
 la puntuación media fue de 22,89 sobre 110 puntos en los criterios generales de evaluación desarrollados para este estudio.''
 Este resultado puede hablar tanto de las expectativas de profesores como de la habilidad de las/los estudiantes,
 pero de cualquier manera,
-nuestra primera recomendación es \recommendation{medir y hacer un seguimiento de los resultados}
+nuestra primera recomendación es \recommendation{mide y haz un seguimiento de los resultados}
 de tal manera que se puedan comparar a través del tiempo para que puedas saber si tus lecciones se están volviendo más o menos efectivas.
 
 \seclbl{¿Qué concepciones erróneas tienen las personas novatas?}{s:pck-misunderstand}
@@ -117,10 +117,10 @@ de tal manera que se puedan comparar a través del tiempo para que puedas saber 
 estrategias para resolver problemas.
 La mayor confusión de las personas novatas ---a veces llamada el ``superbug'' en programación ---es\index{superbug}
 la creencia de que las computadoras entienden lo que las personas quieren decir de la misma manera que cualquier ser humano lo haría~\cite{Pea1986}.
-Nuestra segunda recomendación es entonces \recommendation{enseñar a las personas novatas que las computadoras no entienden los programas},
+Nuestra segunda recomendación es entonces \recommendation{enseña a las personas novatas que las computadoras no entienden los programas},
 es decir, que llamar a una variable ``precio'' no garantiza que su valor sea realmente un precio.
 
-\cite{Sorv2018}  muestra más de cuarenta concepciones erróneas que las/los docentes también pueden intentar aclarar,
+\cite{Sorv2018} muestra más de cuarenta concepciones erróneas que las/los docentes también pueden intentar aclarar,
 muchos de las cuales también se discuten en el estudio de~\cite{Qian2017}.
 Una es la creencia de que las variables en los programas funcionan de la misma manera que en planillas de cálculo,
 es decir, que luego de ejecutar:
@@ -135,7 +135,7 @@ print(total)
 \noindent
 el valor de \texttt{total} será 90 en vez de 75~\cite{Kohn2017}.
 Este es un ejemplo de la forma en que las personas novatas construyen un modelo
-mental plausible pero erróneo haciendo analogías; otras confusiones incluyen:
+mental plausible pero erróneo haciendo analogías. Otras confusiones incluyen:
 
 
 \begin{itemize}
@@ -169,51 +169,51 @@ mental plausible pero erróneo haciendo analogías; otras confusiones incluyen:
 
 \seclbl{¿Qué errores cometen las personas novatas?}{s:pck-mistakes}
 
-Los errores que cometen las personas novatas nos indican que priorizar cuando enseñamos,
+Los errores que cometen las personas novatas nos indican qué priorizar cuando enseñamos,
 pero resulta que la mayoría de las personas que enseñan no saben cuán comunes son los diferentes tipos de errores.
-El el estudio más importante es el de \cite{Brow2017},
+El estudio más importante es el de \cite{Brow2017},
 que encontró que la falta de paréntesis y comillas son el tipo de error más común en programas Java escritos por personas novatas,
-pero además son los más simples de resolver,
-mientras que algunos errores (como poner la condición de un \texttt{if} en \texttt{\{\}} en vez de \texttt{()})
+además de tratarse el error más sencillo de resolver. Por otro lado,
+algunos errores (como poner la condición de un \texttt{if} en \texttt{\{\}} en vez de \texttt{()})
 se cometen solo una vez.
 No extraña que los errores que producen problemas de compilación son resueltos mucho más rápido
 que aquellos que no lo hacen.
 Algunos errores, en cambio, se repiten muchas veces, como llamar métodos con los argumentos incorrectos
-(ej.\ pasar una cadena  de caracteres en vez de un número entero).
+(p. ej.\ pasar una cadena  de caracteres en vez de un número entero).
 
-\begin{aside}{No es correcto vs.\ No está resuelto}
+\begin{aside}{No es correcto versus No está resuelto}
   Una dificultad en una investigación como esta es distinguir los errores del trabajo en proceso.
   Por ejemplo,
   una estructura \texttt{if} vacía o un método que se define pero aún no se ha usado
-  puede ser señal de que el código está incompleto y que no es un error.
+  puede ser señal de que el código está incompleto más que señal de un error.
 \end{aside}
 
 \cite{Brow2017} también comparó los errores que las personas novatas realmente cometen
 con los que sus docentes pensaron que cometieron.
 Descubrieron que,
-``{\ldots}las/los docentes llegaron a un escaso consenso sobre cuales son los errores más frecuentes,
- sus clasificaciones tenían solo una correspondencia moderada con la de las/los estudiantes en los{\ldots}datos,
+``{\ldots}las/los docentes llegaron a un escaso consenso sobre cuáles son los errores más frecuentes.
+Sus calificaciones tenían solo una correspondencia moderada con la de las/los estudiantes en los{\ldots}datos
 y la experiencia de las/los docentes no tuvo ningún efecto en este nivel de acuerdo.''
 Por ejemplo,
-confundir \texttt{=} (asignación) y \texttt{==} (igualdad)
+confundir \texttt{=} (asignación) con \texttt{==} (igualdad)
 no eran tan común como la mayoría de las/los docentes creían.
 
 \begin{aside}{No solo por el código}
-  \cite{Park2015} recopiló datos de un editor HTML en línea, durante un curso introductorio de desarrollo web
-  y encontró que casi todas/os las estudiantes cometieron errores de sintaxis que permanecieron sin ser resueltos por semanas durante el curso.
-  El 20\% de esos errores están relacionados con reglas relativamente complejas
+  \cite{Park2015} recopiló datos de un editor HTML en línea durante un curso introductorio de desarrollo web
+  y encontró que la mayoría de las/los estudiantes cometieron errores de sintaxis que permanecieron sin ser resueltos por semanas durante el curso.
+  El 20\% de esos errores estaban relacionados con reglas relativamente complejas
   que indican \emph{cuándo} es válido que los elementos HTML estén anidados entre sí,
-  pero el 35\% está relacionado a sintaxis de etiquetas más simples que determinan \emph{cómo} los elementos HTML están anidados.
-  La tendencia de muchas/os docentes a decir,
+  pero el 35\% estaba relacionado a sintaxis de etiquetas más simples que determinan \emph{cómo} los elementos HTML están anidados.
+  La tendencia de muchas/os docentes a decir
   ``Pero las reglas son simples,''
   es un buen ejemplo del punto ciego de las personas expertas que se analiza en el \chapref{s:memory}{\ldots}
 \end{aside}
 
 \seclbl{¿Cómo programan las personas novatas?}{s:pck-programming}
 
-\cite{Solo1984,Solo1986} fue pionero en la exploración de las estrategias de programación de personas novatas y expertas.
-El hallazgo clave es que las personas expertas saben al mismo tiempo el ``que'' y el ``como,''
-es decir, entienden que poner en los programas
+\cite{Solo1984,Solo1986} son trabajos pioneros en la exploración de las estrategias de programación de personas novatas y expertas.
+El hallazgo clave es que las personas expertas saben al mismo tiempo el ``qué'' y el ``cómo,''
+es decir, entienden qué poner en los programas
 \emph{y} tienen un conjunto de patrones o plan para guiar su construcción.\index{program patterns}
 Las personas principiantes no tienen ninguna de las dos cosas,
 pero la mayoría de las/los docentes se enfocan únicamente en lo primero,
@@ -223,61 +223,59 @@ Un trabajo reciente mostró la efectividad de enseñar cuatro habilidades distin
 
 \begin{longtable}{lll}
 			& \textbf{semántica del código}				& \textbf{plantillas asociadas a objetivos} \\
-\textbf{leyendo}	& 1.\ Leer el código y predecir su comportamiento	& 3.\ reconocer plantillas y sus usos \\
-\textbf{escribiendo}	& 2.\ Escribir la sintaxis correcta			& 4.\ usar las plantillas para alcanzar objetivos
+\textbf{leyendo}	& 1.\ leer el código y predecir su comportamiento	& 3.\ reconocer plantillas y sus usos \\
+\textbf{escribiendo}	& 2.\ escribir la sintaxis correcta			& 4.\ usar las plantillas para alcanzar objetivos
 \end{longtable}
 
-Por lo tanto, nuestras recomendaciones son
-que \recommendation{estudiantes lean código, luego lo modifiquen, luego lo escriban}, y practiquen usándolos.
-\cite{Mull2007b} es uno de los tantos estudios que muestran los beneficios de enseñar patrones comunes de manera explícita y descomponer los problemas
+Por lo tanto, nuestras siguientes recomendaciones son:
+\recommendation{haz que tus estudiantes lean código, luego lo modifiquen, luego lo escriban} y además  \recommendation{preséntales explícitamente patrones explícitos y haz que practiquen usándolos}.
+\cite{Mull2007b} es uno de los tantos estudios que muestran los beneficios de enseñar patrones comunes de manera explícita. Descomponer los problemas
 en patrones comunes crea oportunidades naturales para crear y etiquetar sub-objetivos~\cite{Marg2012,Marg2016}.\index{labeled subgoals}
 
 \seclbl{¿Cómo identifican y resuelven errores las personas novatas??}{s:pck-debug}
 
 Una década atrás,
-\cite{McCa2008} escribió,
+\cite{McCa2008} escribieron:
 ``Es sorprendente el poco espacio que se dedica a los errores y cómo resolverlos
 en la mayoría de los libros introductorios de programación.''
-
-e \recommendation{introducir patrones comunes explícitamente y que las/los estudiantes.}
 Poco ha cambiado desde entonces:
 hay cientos de libros sobre compiladores y sistemas operativos,
-pero solo unos pocos sobre depuración de errores,\index{debugging}
+pero solo unos pocos sobre depuración de errores \index{debugging}
 y nunca he visto un curso de pregrado dedicado a este tema.
 
-\cite{List2004,List2009} encontró que a muchas personas novatas les cuesta predecir el resultado de pocas líneas de código
+\cite{List2004,List2009} encontraron que a muchas personas novatas les cuesta predecir el resultado de pocas líneas de código
 y seleccionar la salida correcta del código a partir de un conjunto de posibilidades
 cuando les decían lo que se suponía que el código debía hacer. Más recientemente,
-\cite{Harr2018} encontró que la brecha entre poder entender el código y poder escribirlo se ha cerrado en gran medida por CS2,
+\cite{Harr2018} encontraron que la brecha entre poder entender el código y poder escribirlo se ha cerrado en gran medida gracias a CS2,
 pero que las personas novatas que aún tienen esa brecha es probable que les vaya mal.
 
-Nuestra quinta recomendación es entonces \recommendation{enseñar explícitamente a las personas principiantes como depurar errores}.
+Nuestra quinta recomendación es entonces \recommendation{enséñales explícitamente a las personas principiantes cómo depurar errores}.
 \cite{Fitz2008,Murp2008} encontraron que las personas que pueden resolver errores son buenas programando,
 pero no todas las personas que son buenas programando son buenas resolviendo errores.
 Aquellas personas que usaron un depurador de errores simbólico para recorrer sus programas,
 rastrearon su ejecución manualmente,
-escribieron pruebas,
+escribieron pruebas
 y releyeron las especificaciones frecuentemente,
 todos hábitos que se pueden enseñar.
 Sin embargo,
 rastrear la ejecución paso a paso a veces se usa de manera ineficaz:
 por ejemplo,
 una persona novata podría poner la misma declaración \texttt{print} en ambas partes de una estructura \texttt{if}-\texttt{else}.
-Las personas novatas también comentarían líneas de código que en realidad eran correctas al tratar de aislar un problema;
-las/los docentes pueden cometer estos dos errores deliberadamente,
-señalarlos,
-y corregirlos para ayudar a las personas novatas a aprender a resolverlos.
+Las personas novatas también comentarían líneas de código que en realidad eran correctas al tratar de aislar un problema.
+Las/los docentes pueden cometer estos dos errores deliberadamente,
+señalarlos
+y corregirlos para ayudar a las personas novatas a aprender cómo resolverlos.
 
 Enseñar a principiantes cómo depurar errores también puede ayudar a que las clases sean más simples de manejar.
 \cite{Alqa2017} encontró que estudiantes con mayor experiencia resolvieron problemas de depuración de errores significativamente más rápido,
 pero los tiempos variaron ampliamente:
 4--10 minutos fue el rango típico para ejercicios individuales,
 lo cual significa que algunas/os estudiantes necesitan 2--3 más tiempo que otros para resolver el mismo ejercicio.
-Enseñar a estudiantes que hacen las cosas más lentamente, lo que las personas más rápidas están haciendo
-va a ayudar a que el progreso de todo el grupo en general sea más uniforme.
+Para ayudar a que el progreso de todo el grupo sea más uniforme,
+es conveniente enseñarles a quienes hacen aprenden más lentamente qué están haciendo las personas más rápidas.
 
 La depuración de errores depende de ser capaz de leer el código,
-algo quemúltiples estudios han demostrado, que es la forma más efectiva de encontrar errores~\cite{Basi1987,Keme2009,Bacc2013}.
+algo que múltiples estudios han demostrado que es la forma más efectiva de encontrar errores~\cite{Basi1987,Keme2009,Bacc2013}.
 La rúbrica de calidad de código desarrollada por~\cite{Steg2014,Steg2016a}
 es una buena lista de verificación de elementos a revisar,
 aunque se presenta mejor de a partes  en lugar  de toda junta.
@@ -287,39 +285,41 @@ pero frecuentemente lleva mucho tiempo practicarlo en clase.
 Hacer que las/los estudiantes predigan la salida de un programa justo antes de que sea ejecutado,
 por otro lado,
 ayuda a reforzar el aprendizaje (\secref{s:classroom-practices})
-y además les da la oportunidad ideal para hacer el tipo de preguntas ``que pasaría si''.
-Docentes o estudiantes pueden además rastrear los cambios en las variables a medida que avanzan,
+y además les da la oportunidad ideal para hacer el tipo de preguntas ``qué pasaría si''.
+Las/los docentes o estudiantes pueden además rastrear los cambios en las variables a medida que avanzan,
 algo que  \cite{Cunn2017} encontró efectivo (\secref{s:exercises-tracing}).
 
 \seclbl{¿Qué pasa con las pruebas?}{s:pck-testing}
 \index{testing (software)}
 
-Programadoras/es novatas/os parecen tan reacias/os a testear software como aquellas personas profesionales.
+Las personas novatas en programación parecen tan reacias a testear software como aquellas personas profesionales.
 No hay duda de que hacerlo es valioso---\cite{Cart2017} encontró que
-personas novatas con un alto rendimiento dedican mucho tiempo a testear el código,
+las personas novatas con un alto rendimiento dedican mucho tiempo a testear el código,
 mientras que las personas novatas con un bajo rendimiento dedican mucho más tiempo a trabajar en el código con errores---y muchas/os docentes
 requieren que las/los estudiantes escriban pruebas en las actividades.
 ¿Pero qué tan bien lo hacen?
 Una posible respuesta proviene de~\cite{Bria2015},
-que calificó el código de las/los estudiantes según la cantidad de situaciones, definidas por la/el docente, que pasaban correctamente las pruebas de los programas,
-y, a la inversa, calificó los casos de prueba escritos por estudiantes de acuerdo con la cantidad de errores detectados que habían sido sembrados deliberadamente.
-Ellos encontraron que las pruebas de personas novatas usualmente tienen una baja cobertura (es decir, no testean gran parte del código)
+quienes calificaron el código de las/los estudiantes según la cantidad de situaciones, definidas por la/el docente, que pasaban correctamente las pruebas de los programas.
+A la inversa, también calificaron
+los casos de prueba escritos por estudiantes de acuerdo con la cantidad de errores detectados que habían sido sembrados deliberadamente.
+Los autores encontraron que las pruebas de personas novatas usualmente tienen una baja cobertura (es decir, no testean gran parte del código)
 y que usualmente testean muchas cosas al mismo tiempo, lo que dificulta determinar las causas de los errores.
 
 Otra respuesta proviene de ~\cite{Edwa2014b},
-que examinó todos los errores en el código presentado por personas novatas combinados
-e identificó aquellos detectados por el conjunto de pruebas de las/los novatos.
-Ellos encontraron que las pruebas de novatos solo detectaban un promedio de 13.6\% de los errores presentes en la totalidad de los programas.
+quienes examinaron todos los errores en los envíos de códigos realizados por personas novatas
+y a su vez identificaron aquellos errores detectados por el conjunto de pruebas de personas novatas.
+En este trabajo se encontró que las pruebas de personas novatas solo detectaban un promedio de 13,6\% de los errores presentes en la totalidad de los programas.
 Además,
-el 90\% de las pruebas de las/los novatos fueron muy parecidas,
-lo que indica que las/los novatos escriben pruebas principalmente para confirmar que el código está haciendo lo que se supone que debe hacer
+el 90\% de las pruebas de las personas novatos fueron muy parecidas,
+lo que indica que las personas novatas escriben pruebas principalmente para confirmar que el código está haciendo lo que se supone que debe hacer
 en lugar de encontrar situaciones en las que no ocurre esto.
+
 Un enfoque para enseñar mejores prácticas para generar pruebas es
 definir un problema de programación proporcionando un conjunto de pruebas que deben ser pasadas
 en lugar de una descripción (\secref{s:exercises-classics}).
 Sin embargo,
 antes de hacerlo
-tómate un momento para ver cuántas pruebas has escrito en tu propio código recientemente,
+tómate un momento para ver cuántas pruebas has escrito en tu propio código recientemente
 y luego decide si estás enseñando lo que crees que las personas deberían hacer,
  o lo que ellos (y tú) realmente hacen.
 
@@ -327,10 +327,10 @@ y luego decide si estás enseñando lo que crees que las personas deberían hace
 \index{blocks-based programming}
 
 La respuesta corta es ``sí'':
-Las personas novatas aprenden a programar más rápido y aprenden más
+las personas novatas aprenden a programar más rápido y aprenden más
 usando herramientas basadas en bloques como Scratch (\figref{f:pck-scratch})~\cite{Wein2017}.\index{Scratch}
-Una razón es que esos sistemas basados en bloques reduce la carga cognitiva al eliminar la posibilidad de cometer errores de sintaxis.
-Otra razón es que esas interfaces de bloques promueven la exploración de una manera que el texto no lo hace:
+Una razón es que esos sistemas basados en bloques reducen la carga cognitiva al eliminar la posibilidad de cometer errores de sintaxis.
+Otra razón es que esas interfaces de bloques promueven la exploración de una manera que el texto no hace:
 como todas las buenas herramientas,
 Scratch se puede aprender accidentalmente ~\cite{Malo2010}.
 
@@ -340,22 +340,22 @@ tenían calificaciones más altas en cursos introductorios de programación
 en comparación con las personas cuyo primer lenguaje era textual
 cuando los lenguajes se aprendieron durante o antes de los primeros años de adolescencia.
 Nuestra sexta recomendación es
-\recommendation{introducir interfaces basadas bloques a niños, niñas y adolescentes}
+\recommendation{preséntales interfaces basadas bloques a niñas/os y adolescentes}
 antes de avanzar a sistemas basados en texto.
-La calificación de edad corresponde a que  Scratch deliberadamente parece destinado a usuarias y usuarios jóvenes,
-y puede ser difícil convencer a personas adultas para que lo tomen en serio.
+La calificación de edad corresponde a que Scratch deliberadamente parece destinado a usuarias/os jóvenes,
+y puede ser difícil convencer a personas adultas de que lo tomen en serio.
 
 \figimg{figures/scratch-program.png}{Scratch}{f:pck-scratch}
 
 Scratch probablemente ha sido estudiado más que cualquier otra herramienta de programación.
 Un ejemplo es ~\cite{Aiva2016},
-que analizó más de 250.000 proyectos de Scratch
-y encontró (entre otras cosas) que alrededor del 28\% de esos proyectos tenían algunos bloques que nunca eran usados o activados.
+quienes analizaron más de 250.000 proyectos de Scratch
+y encontraron (entre otras cosas) que alrededor del 28\% de esos proyectos tenían algunos bloques que nunca eran usados o activados.
 Como en la sección anterior sobre los programas en Java incompletos versus incorrectos,
-los autores plantean la hipótesis de que los usuarios pueden estar utilizando estos bloques como borrador
+las autoras plantean la hipótesis de que las/los usuarias/os pueden estar utilizando estos bloques como borrador
 para hacer un seguimiento de las partes del código que no quieren eliminar (todavía).
 Otros ejemplos son~\cite{Grov2017,Mlad2017},
-que estudiaron a personas novatas aprendiendo sobre bucles en Scratch, Logo, y Python.\index{Scratch}\index{Python}
+que estudiaron a personas novatas aprendiendo sobre bucles en Scratch, Logo y Python.\index{Scratch}\index{Python}
 Encontraron que las ideas erróneas sobre bucles se minimizan cuando se usa un lenguaje basado en bloques
 en lugar de un lenguaje basado en texto.
 Además,
@@ -508,7 +508,7 @@ dado que quienes hacen esquemas llevan significativamente más tiempo resolver l
 ¿lo hacen mejor solo porque piensan por más tiempo?
 La respuesta es no:
 no encontraron correlación entre el tiempo que se tomaron y el puntaje alcanzado.
-Nuestra recomendación es, por lo tanto, \recommendation{enseñar a rastrear los valores que toman las variables al depurar errores}.
+Nuestra recomendación es, por lo tanto, \recommendation{enseña a rastrear los valores que toman las variables al depurar errores}.
 
 \begin{aside}{Diagramas de flujo}\index{flowcharts}
   Un hallazgo que a menudo se pasa por alto sobre la visualización es que

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -586,7 +586,7 @@ lo que indica una mayor autoeficacia y disposición para depurar cosas.
   hacer que las personas novatas trabajen en ejercicios de creatividad computacional mejora sus calificaciones en varios niveles~\cite{Shel2017}.
   Un ejercicio típico es describir un objeto cotidiano (como un clip o un cepillo de dientes)
   en términos de sus entradas, salidas y funciones.
-  Este tipo de enseñanza a veces se es llamada \grefdex{g:cs-unplugged}{desconectado}{CS unplugged};
+  Este tipo de enseñanza a veces se es llamada \grefdex{g:cs-unplugged}{CS desconectado};
   La página web \hreffoot{https://csunplugged.org/en/}{CS~Unplugged} tiene lecciones y ejercicios para esto.
 \end{aside}
 

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -38,7 +38,7 @@ se requiere cierta precaución al interpretar los resultados:
   viven en sociedades occidentales, democráticas, industrializadas y con alto nivel de riqueza y educación], tal como señala ~\cite{Henr2010}.
   Además,
   son principalmente jóvenes que estudian en instituciones educativas, ya que es la población a la que la mayoría de las personas que investigan tienen fácil acceso.
-  Sabemos mucho menos sobre adultos, grupos marginados y estudiantes en ambientes educativos flexibles (estudiantes free-range), así como sobre \grefdex{g:end-user-programmer}{usuarias/os finales programadoras/es}{usuario final programador},
+  Sabemos mucho menos sobre adultos, grupos marginados y estudiantes en ambientes educativos flexibles (estudiantes free-range), así como sobre \grefdex{g:end-user-programmer}{usuarias/os finales programadoras/es},
   aún cuando son la mayoría.
 
 \end{description}

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -269,7 +269,7 @@ y corregirlos para ayudar a las personas novatas a aprender cómo resolverlos.
 
 Enseñar a principiantes cómo depurar errores también puede ayudar a que las clases sean más simples de manejar.
 \cite{Alqa2017} encontró que estudiantes con mayor experiencia resolvieron problemas de depuración de errores significativamente más rápido,
-pero los tiempos variaron ampliamente:
+pero que los tiempos variaron ampliamente:
 4--10 minutos fue el rango típico para ejercicios individuales,
 lo cual significa que algunas/os estudiantes necesitan entre 2 y 3 veces más tiempo que otras/os para resolver el mismo ejercicio.
 Para ayudar a que el progreso de todo el grupo sea más uniforme,

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -273,7 +273,7 @@ pero los tiempos variaron ampliamente:
 4--10 minutos fue el rango típico para ejercicios individuales,
 lo cual significa que algunas/os estudiantes necesitan 2--3 más tiempo que otros para resolver el mismo ejercicio.
 Para ayudar a que el progreso de todo el grupo sea más uniforme,
-es conveniente enseñarles a quienes hacen aprenden más lentamente qué están haciendo las personas más rápidas.
+es conveniente enseñarles a quienes resuelven los ejercicios más lentamente qué están haciendo las personas más rápidas.
 
 La depuración de errores depende de ser capaz de leer el código,
 algo que múltiples estudios han demostrado que es la forma más efectiva de encontrar errores~\cite{Basi1987,Keme2009,Bacc2013}.

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -114,7 +114,7 @@ de tal manera que se puedan comparar a través del tiempo para que puedas saber 
 
 \seclbl{¿Qué conceptos erróneos tienen las personas novatas?}{s:pck-misunderstand}
 
-\chapref{s:models} explicó por qué aclarar los conceptos erróneos a las personas novatas es tan importante como enseñarles
+El \chapref{s:models} explicó por qué aclarar los conceptos erróneos a las personas novatas es tan importante como enseñarles
 estrategias para resolver problemas.
 La mayor confusión de las personas novatas ---a veces llamada el \emph{``superbug''} o ``supererror'' en programación ---es\index{superbug}
 la creencia de que las computadoras entienden lo que las personas quieren decir de la misma manera que cualquier ser humano lo haría~\cite{Pea1986}.

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -290,7 +290,7 @@ y además les da la oportunidad ideal para hacer el tipo de preguntas ``qué pas
 Las/los docentes o estudiantes pueden además rastrear los cambios en las variables a medida que avanzan,
 algo que \cite{Cunn2017} encontró efectivo (\secref{s:exercises-tracing}).
 
-\seclbl{¿Qué pasa con las pruebas?}{s:pck-testing}
+\seclbl{¿Qué pasa con las pruebas (\emph{tests})?}{s:pck-testing}
 \index{testing (software)}
 
 Las personas novatas en programación parecen tan reacias a testear software como aquellas personas profesionales.

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -288,7 +288,7 @@ por otro lado,
 ayuda a reforzar el aprendizaje (\secref{s:classroom-practices})
 y además les da la oportunidad ideal para hacer el tipo de preguntas ``qué pasaría si''.
 Las/los docentes o estudiantes pueden además rastrear los cambios en las variables a medida que avanzan,
-algo que  \cite{Cunn2017} encontró efectivo (\secref{s:exercises-tracing}).
+algo que \cite{Cunn2017} encontró efectivo (\secref{s:exercises-tracing}).
 
 \seclbl{¿Qué pasa con las pruebas?}{s:pck-testing}
 \index{testing (software)}

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -753,19 +753,19 @@ Las preguntas favoritas de las/los investigadoras/es fueron:
 \begin{enumerate}
 
 \item                              
-  ¿Qué conceptos fundamentales de programación son los más desafiantes para los estudiantes?
+  ¿Qué conceptos fundamentales de programación son los más desafiantes para las/los estudiantes?
 
 \item
   ¿Qué estrategias de enseñanza son más efectivas cuando se trata de una amplia gama de experiencias previas en clases introductorias de programación?
 
 \item
-  ¿Qué afecta la capacidad de los estudiantes para generalizar a partir de ejemplos de programación simples?
+  ¿Qué afecta la capacidad de las/los estudiantes para generalizar a partir de ejemplos de programación simples?
 
 \item
-  ¿Qué prácticas de enseñanza para enseñar computación a niñas y niños?
+  ¿Qué prácticas de enseñanza son más efectivas para enseñar computación a niñas/os?
 
 \item
-  ¿Qué tipo de problemas encuentran las personas en las clases de programación más interesantes?    
+  ¿Qué tipo de problemas de una clase de computación resultan más interesantes para las personas?    
 
 \item
   ¿Cuáles son las formas más efectivas de enseñar programación a varios grupos?
@@ -784,16 +784,16 @@ Mientras que las preguntas más importantes para las personas que no investigan 
   ¿Cómo y cuándo es mejor dar retroalimentación a las/los estudiantes sobre su código para mejorar el aprendizaje?
 
 \item
-  ¿Qué tipo de ejercicios de programación son más efectivos al enseñar a estudiantes de Ciencias de la Computación?
+  ¿Qué tipo de ejercicios de programación son más efectivos al enseñar a estudiantes de iencias de la Computación?
 
 \item
   ¿Cuáles son los méritos relativos del aprendizaje basado en proyectos, las clases y el aprendizaje activo, para estudiantes de computación?
 
 \item
-  ¿Cuál es la forma más efectiva de hacer comentarios a los estudiantes en las clases de programación?
+  ¿Cuál es la forma más efectiva de hacer comentarios a las/los estudiantes en las clases de programación?
 
 \item
-  ¿Qué les resulta más difícil a las personas cuando dividen los problemas en tareas más pequeñas mientras programan?
+  Al dividir los problemas en tareas más pequeñas mientras programan, ¿qué les resulta más difícil de aprender a las personas?
 
 \item
   ¿Cuáles son los conceptos clave que las/los estudiantes deben entender en las clases introductorias de computación?
@@ -806,10 +806,8 @@ Mientras que las preguntas más importantes para las personas que no investigan 
 
 \end{enumerate}
 
-Haga que cada persona de la clase, independientemente, le otorgue un punto a las
-las ocho preguntas de las listas combinadas que más le interesan,
-luego calcule el puntaje promedio para cada pregunta.
-¿Cuáles son las más populares en tu clase?
+Haz que cada persona de la clase, independientemente, le otorgue un punto a las
+las ocho preguntas que más les interese, de cualquiera de las dos listas.
+Luego, calcula el puntaje promedio para cada pregunta.
+¿Cuáles son las preguntas más populares en tu clase?
 ¿En qué grupo  están las preguntas más populares?
-
-

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -75,7 +75,7 @@ Títulos de temas de alto nivel como estos pueden esconder una gran cantidad de 
 Un resultado más tangible surge de \cite{Rich2017},
 quienes revisaron cien artículos y encontraron trayectorias de aprendizaje para clases de computación en escuelas primarias y secundarias.
 Sus resultados para la secuenciación, la repetición y los condicionales son esencialmente mapas conceptuales colectivos
-que combinan y racionalizan el pensamiento implícito y explícito de gran cantidad de docentes.
+que combinan y racionalizan el pensamiento implícito y explícito de gran cantidad de docentes
 (\figref{f:pck-trajectory}).
 
 \newpage

--- a/es/pck.tex
+++ b/es/pck.tex
@@ -587,7 +587,7 @@ lo que indica una mayor autoeficacia y disposición para depurar cosas.
   Un ejercicio típico es describir un objeto cotidiano (como un clip o un cepillo de dientes)
   en términos de sus entradas, salidas y funciones.
   Este tipo de enseñanza a veces se es llamada \grefdex{g:cs-unplugged}{CS desconectado};
-  La página web \hreffoot{https://csunplugged.org/en/}{CS~Unplugged} tiene lecciones y ejercicios para esto.
+  La página web \hreffoot{https://csunplugged.org/es/}{CS~Unplugged} tiene lecciones y ejercicios para esto.
 \end{aside}
 
 \seclbl{¿Qué sigue?}{s:pck-final}


### PR DESCRIPTION
**Revisión general de pck.tex**

**Decisiones más relevantes que tomé:**
- Quito sigla PCK
- Quito sigla CER
- Quito sigla WEIRD
- Quito referencias a educación formal/no-formal porque entiendo que Greg no acuerda con usarlas; uso free-range
- En las recomendaciones, paso a 2da persona en vez de infinitivo (_"haz que tus estudiantes..."_)

**Revisar:**
- _"Tomando el primer enfoque, "_ lo dejo así pero no sé a qué se refiere.
- testear. Lo dejo así. Ver si se traduce o no.
- Me resulta confuso y no termino de entender: _"Otra respuesta proviene de ~\cite{Edwa2014b},
quienes examinaron todos los errores en los envíos de códigos realizados por personas novatas
y a su vez identificaron aquellos errores detectados por el conjunto de pruebas de personas novatas."_ (revisar hasta el final del párrafo).