### PR TITLE
Revision of performance.tex [es]

### DIFF
--- a/es/book.bib
+++ b/es/book.bib
@@ -2645,7 +2645,7 @@
   doi = {10.1016/j.compedu.2014.08.005},
   link = {https://doi.org/10.1016/j.compedu.2014.08.005},
   local = {margaryan-2015-moocs.pdf},
-  note = {Informa que la calidad del diseño instruccional en los cursos masivos en línea MOOCs es deficiente, pero que la organización y presentación del material es buena.}
+  note = {Informa que la calidad del diseño instruccional en los cursos abiertos masivos en línea (MOOCs) es deficiente, pero que la organización y presentación del material es buena.}
 }
 
 @book{Marg2003,

--- a/es/performance.tex
+++ b/es/performance.tex
@@ -321,7 +321,7 @@ en frente de jóvenes de 16 años aburridos/as no es algo por lo que alguna vez 
   Es más como un actor recitando líneas que como el enfoque de improvisación que recomendamos.
   \cite{Stoc2018} encontró que la enseñanza directa tiene un efecto estadísticamente significativo positivo
   a pesar de que a veces pueda ser muy repetitivo.
-  Yo prefiero improvisar porque la enseñanza requiere más preparación inicial que lo que la mayoría
+  Yo prefiero improvisar porque la enseñanza directa requiere más preparación inicial que lo que la mayoría
   de los grupos de estudiantes free-range pueden permitirse.
 \end{aside}
 

--- a/es/performance.tex
+++ b/es/performance.tex
@@ -588,7 +588,7 @@ La mejor manera de perfecccionar la forma en que damos clases en persona es obse
 
 \item
   Cada persona rota entre los roles de docente, público y quien graba.
-  La persona en el rol docente tiene 2 minutos para explicar algo.
+  La persona en el rol docente tiene dos minutos para explicar algo.
   La persona que pretende ser el público está allí para prestar atención,
   mientras que la tercera persona graba la sesión con un teléfono u otro dispositivo portátil.
 

--- a/es/performance.tex
+++ b/es/performance.tex
@@ -157,8 +157,9 @@ Hagas lo que hagas,
 \emph{no} copies y pegues código:
 hacer eso prácticamente garantiza que irás mucho más rápido que tus estudiantes.
 Y si usas la tecla Tab para autocompletar lo que estás escribiendo,
-dilo en voz alta para que tus estudiantes entiendan qué estás haciendo:
-``Usemos tortuga punto `r' `i' y Tab para completar con `right'.''
+dilo en voz alta para que tus estudiantes entiendan qué estás haciendo, 
+como en el siguiente ejemplo para el lenguage Python:
+``Usemos \emph{turtle} punto `r' `i' y Tab para completar con `right'.''
 
 Si la salida de tu comando o código hace que lo que acabas de escribir desaparezca de la vista,
 vuelve arriba para que tus estudiantes puedan verlo de nuevo.

--- a/es/performance.tex
+++ b/es/performance.tex
@@ -90,7 +90,7 @@ y la importancia de definir un plan en vez de hacer
 cambios más o menos aleatorios y esperar que las cosas mejoren~\cite{Spoh1985}.
 
 Sentirse cómodo/a al hablar mientras se escribe código en
-frente de público requiere práctica,
+frente de un público requiere práctica,
 pero la mayoría de las personas indican que rápidamente se vuelve igual de difícil que hablar con una presentación de diapositivas.
 Las secciones que siguen ofrecen consejos sobre cómo mejorar la manera de programar en vivo.
 

--- a/es/performance.tex
+++ b/es/performance.tex
@@ -2,11 +2,11 @@
 
 En \emph{Darwin entre las máquinas},
 George Dyson\index{Dyson, George} escribió,
-``En el juego de la vida y la evolución hay 3 jugadores en la mesa:
+``En el juego de la vida y la evolución hay tres jugadores en la mesa:
 los humanos, la naturaleza y las máquinas.
 Estoy firmemente del lado de la naturaleza.
 Pero la naturaleza, sospecho, está del lado de las máquinas{\ldots}''
-De manera similar, ahora hay 3 jugadores en el juego de la educación:
+De manera similar, ahora hay tres jugadores en el juego de la educación:
 los libros de texto y otros materiales de lectura,
 las clases en vivo,
 y las clases en línea automatizadas.
@@ -36,10 +36,10 @@ Programar en vivo funciona mejor que las presentaciones por varias razones:
 
 \item
   Permite la \gref{g:active-teaching}{enseñanza activa}
-  al permitir a quienes están enseñando responder a los intereses y preguntas de los/las estudiantes en el momento.
+  al facilitar a quienes están enseñando responder a los intereses y preguntas de los/las estudiantes en el momento.
   Una presentación de diapositivas es como una vía de ferrocarril:
   podrá ser un viaje suave,
-  pero tienes que decidir hacia donde vas con anticipación.
+  pero tienes que decidir hacia dónde vas con anticipación.
   Programar en vivo es como manejar un vehículo todo terreno:
   podrá ser más accidentado,
   pero es mucho más fácil cambiar de dirección e ir hacia donde la gente quiere.
@@ -56,8 +56,8 @@ Programar en vivo funciona mejor que las presentaciones por varias razones:
 \item
   Disminuye la velocidad de la persona que está enseñando:
   si tiene que escribir el programa a medida que avanza,
-  entonces solo puede ir el doble de rápido que sus estudiantes
-  en vez de 10 veces más rápido como lo haría usando diapositivas.
+  entonces solo puede ir el doble de rápido que sus estudiantes,
+  en vez de 10 veces más rápido como haría usando diapositivas.
 
 \item
   Ayuda a reducir la carga en la memoria de corto plazo
@@ -65,13 +65,13 @@ Programar en vivo funciona mejor que las presentaciones por varias razones:
   le está mostrando a sus estudiantes.
 
 \item
-  Los/Las estudiantes pueden ver cómo diagnosticar y corregir errores.
+  Los/las estudiantes pueden ver cómo diagnosticar y corregir errores.
   Van a dedicar mucho tiempo a esta tarea;
   a menos que puedan tipear de manera perfecta,
   programar en vivo asegura que puedan ver cómo resolver los errores de programación.
 
 \item
-  Ver a quienes enseñan cometer errores muestra a los estudiantes que está bien que cometan errores.
+  Ver a quienes enseñan cometer errores muestra a los/las estudiantes que está bien que cometan errores.
   Si el/la docente no se avergüenza al cometer errores y habla sobre ellos,
   sus estudiantes también se sentirán más cómodos/as haciéndolo.
 
@@ -81,16 +81,16 @@ Otro beneficio de la programación en vivo es que demuestra el orden en que se d
 Cuando \cite{Ihan2011} observaron cómo las personas resuelven problemas de Parson,\index{Parsons Problem}
 encontraron que quienes tienen experiencia programando usualmente ubican la identificación del método al principio,
 luego agregan la mayor parte del control de flujo (es decir, bucles y condiciones),
-y solo luego de eso, agregan detalles como la inicialización de variables y el manejo de casos especiales.
+y solo después de eso, agregan detalles como la inicialización de variables y el manejo de casos especiales.
 Este método ``fuera de orden'' es ajeno para las personas novatas,
 que leen y escriben código en el orden en que se presenta en la página;
-ver el código les ayuda a descomponer los problemas en submetas que pueden abordar una a la vez.
+ver el código les ayuda a descomponer los problemas en sub\-metas que pueden abordar una a la vez.
 La programación en vivo además les da a quienes están enseñando la chance de enfatizar la importancia de los pequeños pasos con comentarios frecuentes~\cite{Blik2014}
 y la importancia de definir un plan en vez de hacer
 cambios más o menos aleatorios y esperar que las cosas mejoren~\cite{Spoh1985}.
 
 Sentirse cómodo/a al hablar mientras se escribe código en
-frente de una audiencia, requiere práctica,
+frente de público requiere práctica,
 pero la mayoría de las personas indican que rápidamente se vuelve igual de difícil que hablar con una presentación de diapositivas.
 Las secciones que siguen ofrecen consejos sobre cómo mejorar la manera de programar en vivo.
 
@@ -104,15 +104,15 @@ Las secciones que siguen ofrecen consejos sobre cómo mejorar la manera de progr
 \end{quote}
 
 La regla más importante de la programación en vivo es aprovechar tus errores.\index{mistakes (importance of embracing)}
-No importa que tan bien te prepares,
+No importa qué tan bien te prepares,
 cometerás algunos errores;
 cuando lo hagas,
-piensa sobre ellos con tu audiencia.
+piensa sobre ellos con tu público.
 Si bien obtener datos es difícil,
-programadores/as profesionales dedican del 25\% al 60\% de su tiempo identificando y resolviendo errores;
-las personas novatas le dedican mucho más (\secref{s:pck-debug}),
-pero la mayoría de los libros de texto y tutoriales dedican poco tiempo a diagnosticar y corregir problemas.
-Si hablas en voz alta mientras intentas identificar que escribiste mal
+los/las programadores/as profesionales dedican del 25\% al 60\% de su tiempo identificando y resolviendo errores;
+las personas novatas le dedican mucho más (\secref{s:pck-debug}).
+A pesar de ello, la mayoría de los libros de texto y tutoriales dedican poco tiempo a diagnosticar y corregir problemas.
+Si hablas en voz alta mientras intentas identificar qué escribiste mal
 o dónde tomaste el camino equivocado,
 y explicas cómo lo corriges,
 les darás a tus estudiantes un conjunto de herramientas que pueden usar cuando comentan sus propios errores.
@@ -125,40 +125,40 @@ les darás a tus estudiantes un conjunto de herramientas que pueden usar cuando 
   Puedes intentar recordar errores pasados y cometerlos deliberadamente,
   pero usualmente eso se siente forzado.
   Un enfoque alternativo es \gref{g:twitch-coding}{sacudir la programación}:
-  pide a tus estudiantes, uno a uno, que te indiquen qué escribir a continuación.
+  pide a tus estudiantes, en turnos, que te indiquen qué escribir a continuación.
   Esto prácticamente garantiza que te encuentres en algún tipo de problema.
 \end{aside}
 
 \subsection*{Pregunta por predicciones}
 
-Una manera de mantener a tus estudiantes motivados/as mientras estás programando en vivo
+Una manera de mantener la motivación de tus estudiantes mientras estás programando en vivo
 es pedirles que hagan predicciones sobre qué hará el código que ven en la pantalla.
 Luego, puedes escribir las primeras sugerencias que hagan,
 hacer que toda la clase vote sobre cuál piensan que es la opción más probable,
 y finalmente ejecutar el código.
 Esta es una forma simple de instrucción entre pares,\index{peer instruction}
-que discutiremos en la sección \secref{s:classroom-peer};
-además de mantener su atención en la actividad,
+que discutiremos en la sección \secref{s:classroom-peer}.
+Además de mantener su atención en la actividad,
 les permite practicar cómo razona sobre el comportamiento del código.
 
 \subsection*{Tómalo con calma}
 
 Cada vez que escribas un comando,
-agregues una línea de código a un programa,
+agregues una línea de código a un programa
 o selecciones un elemento de un menú,
-di que estas haciendo en voz alta,
-luego señala lo que haz hecho y su resultado en la pantalla
+di qué estas haciendo en voz alta.
+Luego señala lo que haz hecho y su resultado en la pantalla
 y repásalo una segunda vez.
-Esto ayuda a tus estudiantes a ponerse al día
-y a revisar que lo que acaban de hacer es correcto.
+Así tus estudiantes podrán ponerse al día
+y revisar si lo que acaban de hacer es correcto.
 Esto es particularmente importante cuando algunos de tus estudiantes tienen dificultades para ver o escuchar o no dominan el idioma en el que estás enseñando.
 
 Hagas lo que hagas,
 \emph{no} copies y pegues código:
 hacer eso prácticamente garantiza que irás mucho más rápido que tus estudiantes.
-Y si usas la tecla tab para autocompletar lo que estás escribiendo,
-dilo en voz alta para que tus estudiantes entiendan lo que estás haciendo:
-``Usemos tortuga punto `r' `i' y tab para completar con `right'.''
+Y si usas la tecla Tab para autocompletar lo que estás escribiendo,
+dilo en voz alta para que tus estudiantes entiendan qué estás haciendo:
+``Usemos tortuga punto `r' `i' y Tab para completar con `right'.''
 
 Si la salida de tu comando o código hace que lo que acabas de escribir desaparezca de la vista,
 vuelve arriba para que tus estudiantes puedan verlo de nuevo.
@@ -166,10 +166,10 @@ Si eso no es posible,
 ejecuta el mismo comando una segunda vez
 o copia y pega el último comando o comandos en las notas compartidas del taller.
 
-\subsection*{Ser visto/a y escuchado/a}
+\subsection*{Visible y con voz clara}
 
 Cuando te sientas,
-es más probable que mires tu pantalla en vez de mirar a tu audiencia
+es más probable que mires tu pantalla en vez de mirar a tu público
 y puedes quedar fuera de la vista de tus estudiantes en las últimas filas del aula.
 Si eres físicamente capaz de pararte durante un par de horas,
 debes hacerlo mientras enseñas.
@@ -183,7 +183,7 @@ Independientemente de si estás de pie o sentado/a,
 asegúrate de moverte lo más que puedas:
 acércate a la pantalla para señalar algo,
 dibuja algo en la pizarra,
-o simplemente aléjate de la computadora por un momento y háblale directamente a tu audiencia.
+o simplemente aléjate de la computadora por un momento y háblale directamente a tu público.
 Hacer esto aleja la atención de tus estudiantes de sus pantallas
 y les proporciona un momento natural para hacer preguntas.
 
@@ -196,8 +196,8 @@ También puede marcar una gran diferencia para las personas que tienen discapaci
 
 \subsection*{Emula la pantalla de tu estudiante}
 
-Es posible que hayas personalizado tu entorno de trabajo con una terminal de Unix shell elegante,
-un esquema de colores personalizado,
+Es posible que hayas personalizado tu entorno de trabajo con una terminal de Unix elegante,
+un esquema de colores personalizado
 o una gran cantidad de atajos de teclado.
 Tus estudiantes no tendrán nada de eso,
 así que intenta crear un entorno de trabajo que refleje lo que \emph{sí} tienen.
@@ -213,17 +213,17 @@ Por lo general, necesitarás agrandar el tamaño de la letra considerablemente
 para que las personas en el fondo de la sala puedan leer.
 Esto significa que podrás colocar muchas menos cosas en la pantalla de las que estás acostumbrado/a.
 En muchos casos, se reducirá a 60--70 columnas y 20--30 filas,
-por lo que estarás usando una super computadora del siglo 21
+por lo que estarás usando una super computadora del siglo XXI
 como si fuera una sencilla terminal de principios de la década de 1980.
 
-Para organizar esto,
+Para organizarte,
 maximiza la ventana que estás usando para enseñar
 y luego pregúntale a todos si pueden leer lo que está en la pantalla o no.
 Usa una fuente de color negro sobre un fondo ligeramente coloreado en vez de una fuente de color claro sobre un fondo oscuro---el tono claro deslumbrará
 menos que el blanco puro.
 
 Presta atención a la iluminación de la sala:
-no debe estar completamente a oscuras, y no debe haber luces directamente
+no debe estar completamente a oscuras y no debe haber luces directamente
 o por encima de la pantalla de protección.
 Dedica algunos minutos para que tus estudiantes puedan reacomodar sus mesas
 para ver con claridad.
@@ -238,21 +238,21 @@ Si puedes acceder a un segundo proyector y pantalla,
 el espacio adicional te permitirá mostrar el código de un lado
 y su resultado o comportamiento del otro lado.
 Si la segunda pantalla requiere su propia computadora,
-pídele a un/a ayudante que la controle
+pídele a un docente auxiliar que la controle
 en lugar de ir y venir entre los dos teclados.
 
 Finalmente,
-si estás enseñando algo como la terminal de Unix shell en una consola,
-es importante decirle a las personas cuando estás usando un editor de texto en la consola
-y cuando regresas a la consola propiamente dicha.
-La mayoría de las personas novatas no han visto nunca a una ventana asumir múltiples personalidades de esta manera,
+si estás enseñando algo como la terminal de Unix en una consola,
+es importante decirle a las personas cuándo estás usando un editor de texto en la consola
+y cuándo regresas a la consola propiamente dicha.
+La mayoría de las personas novatas no han visto nunca a una ventana asumir múltiples personalidades de esta manera
 y pueden confundirse rápidamente
 cuando estás interactuando en la terminal,
 cuando estás escribiendo en un editor de texto,
 y cuando estás trabajando de manera interactiva con Python u otro lenguaje.
-Puedes evitar este problema usando ventanas separadas para usar el editor de texto;
+Puedes evitar este problema usando ventanas separadas para el editor de texto;
 si haces esto,
-siempre avisa a tus estudiantes cuando estás cambiando de una ventana a la otra.
+siempre avisa a tus estudiantes al cambiar de una ventana a la otra.
 
 \begin{aside}{Las herramientas de accesibilidad ayudan a todas las personas}
 
@@ -261,7 +261,7 @@ siempre avisa a tus estudiantes cuando estás cambiando de una ventana a la otra
   resaltan la posición del cursor del mouse en la pantalla,
   y las herramientas de grabación de pantalla como \hreffoot{https://www.techsmith.com/video-editor.html}{Camtasia}
   y aplicaciones independientes como \hreffoot{https://github.com/keycastr/keycastr}{KeyCastr}
-  muestran teclas invisibles como tab y Control-J a medida que las usas.
+  muestran teclas invisibles como Tab y Control-J a medida que las usas.
   Esto puede ser un poco molesto al comienzo,
   pero ayuda a tus estudiantes a descubrir lo que estás haciendo.
 \end{aside}
@@ -269,8 +269,8 @@ siempre avisa a tus estudiantes cuando estás cambiando de una ventana a la otra
 \subsection*{Dos dispositivos}
 
 Algunas personas usan dos dispositivos cuando enseñan:
-una computadora portátil conectada al proyector que los/as estudiantes ven
-y una tablet para que puedan ver sus propias notas y las notas que los/as estudiantes están tomando (\secref{s:classroom-notetaking}).
+una computadora portátil conectada al proyector que sus estudiantes ven
+y una tableta para que puedan ver sus propias notas y las notas que los/las estudiantes están tomando (\secref{s:classroom-notetaking}).
 Esto es más confiable que pasar de un escritorio virtual al otro,
 aunque imprimir la lección sigue siendo la tecnología de respaldo más confiable.
 
@@ -311,16 +311,16 @@ Cuando quieras usar algo nuevo,
 revísalo de antemano
 \emph{usando la misma computadora que usarás cuando des la clase}:
 instalar cientos de megabytes de programas a través del WiFi de la escuela secundaria
-en frente de jóvenes de 16 años aburridos no es algo por lo que alguna vez quieras pasar.
+en frente de jóvenes de 16 años aburridos/as no es algo por lo que alguna vez quieras pasar.
 
 \begin{aside}{Enseñanza directa}
 
-  La \gref{g:direct-instruction}{Enseñanza directa} (ED) es un método de enseñanza
+  La \gref{g:direct-instruction}{Enseñanza directa} es un método de enseñanza
   centrado en el diseño meticuloso del plan de estudio dictado usando un guíon predefinido.
   Es más como un actor recitando líneas que como el enfoque de improvisación que recomendamos.
-  \cite{Stoc2018} encontró que la ED tiene un efecto estadísticamente significativo positivo
+  \cite{Stoc2018} encontró que la enseñanza directa tiene un efecto estadísticamente significativo positivo
   a pesar de que a veces pueda ser muy repetitivo.
-  Yo prefiero improvisar porque la ED requiere más preparación inicial que lo que la mayoría
+  Yo prefiero improvisar porque la enseñanza requiere más preparación inicial que lo que la mayoría
   de los grupos de estudiantes free-range pueden permitirse.
 \end{aside}
 
@@ -349,11 +349,11 @@ para que solo tengas que pensar en un pequeño paso a la vez.
 Y si sientes que estás pasando demasiado tiempo escribiendo código para importar librerías, encabezados de clases y código repetitivo,
 genera un esqueleto de código para que tú y tus estudiantes usen como punto de partida (\secref{s:classroom-blank}).
 Hacer esto también reducirá su carga cognitiva,
-dado que centrarán su atención donde tu quieras.
+dado que centrarán su atención donde tú quieras.
 
 \seclbl{Estudiar la lección}{s:performance-jugyokenkyu}
 
-Desde políticos hasta investigador/as y docentes,
+Desde políticos/as hasta investigadores/as y docentes,
 quienes reforman la educación han diseñado sistemas
 para encontrar y apoyar a personas que pueden enseñar bien
 y eliminar a las personas que no lo hacen.
@@ -368,19 +368,19 @@ que significa ``estudiar la lección'':
 \begin{quote}
 
   Para graduarse,
-  los/as especialistas en educación [japoneses] no solo tenían que ver como trabaja el/la docente que le asignan,
+  los/las especialistas en educación [de Japón] no solo tenían que ver como trabajaba el/la docente que le asignaban,
   tenían que reemplazarlo/a efectivamente,
   participando en su aula primero como observadores/as y luego,
   a la tercera semana,
-  como una aproximación{\ldots}titubeante del/la propio/a docente.
+  como una aproximación{\ldots}titubeante del propio/a docente.
   Funcionó como una especie de relevo de docentes.
   Cada estudiante eligió una asignatura,
-  preparando clases para 5 días{\ldots} [y luego] cada uno/a enseñó un día.
+  preparando clases para cinco días{\ldots} [y luego] cada uno/a enseñó un día.
   Para pasar la batuta,
   tenía que enseñar una clase de un día en cada asignatura:
-  la que tenían planeada y las 4 que no{\ldots}
+  la que tenían planeada y las cuatro que no{\ldots}
   y tenían que hacerlo delante de su docente.
-  Después, todos/as---el/la docente, los/las estudiantes para ser docentes,
+  Después, todas las personas---el/la docente, los/las estudiantes para ser docentes,
   y a veces, incluso un/a observador/a externo---se sentaban alrededor de una mesa
   para hablar sobre lo que observaron.
 
@@ -400,7 +400,7 @@ quienes enseñan no miran las clases de sus colegas de manera regular,
 por lo que no pueden tomar prestadas las buenas ideas de las demás personas.
 Los/as docentes podrán acceder a los planes de clases y tareas de sus colegas,
 la junta escolar o una editorial de libros de texto,
-o revisar MOOCs en Internet,
+o revisar cursos masivos abiertos en línea,
 pero cada persona tiene que descubrir
 cómo dar las clases específicas en aulas específicas para estudiantes específicos/as.
 Esto es particularmente cierto para personas voluntarias y docentes free-range
@@ -412,8 +412,8 @@ y dar \grefdex{g:demonstration-lesson}{lecciones de demostración}{demonstration
 no son la solución.
 Por ejemplo,
 \cite{Finc2007,Finc2012} encontraron que de los 99 historiales analizados,
-quienes enseñan solo buscaron activamente nuevas prácticas o materiales en 3 casos,
-y solo consultaron material publicado en 8.
+quienes enseñan solo buscaron activamente nuevas prácticas o materiales en tres casos,
+y solo consultaron material publicado en ocho oportunidades.
 La mayoría de los cambios se dieron localmente,
 sin aportes de fuentes externas,
 o solo involucraron comunicación personal con otros/as docentes.
@@ -423,7 +423,7 @@ o solo involucraron comunicación personal con otros/as docentes.
 
   La adopción no es una ``acción racional''{\ldots}sino
   una serie iterativa de decisiones tomadas en un contexto social,
-  basado en tradiciones normativas, señales sociales,
+  en base a tradiciones normativas, señales sociales,
   y procesos emocionales o intuitivos{\ldots}
   No es probable que los/las docentes utilicen los resultados de investigaciones en educación
   como base para tomar decisiones{\ldots}
@@ -435,10 +435,10 @@ o solo involucraron comunicación personal con otros/as docentes.
 \emph{Jugyokenkyu} funciona porque maximiza la oportunidad de transferencia de conocimiento no planificada entre docentes:
 alguien se propone demostrar X,
 pero mientras lo miran,
-su audiencia también (o en su lugar) aprende Y.
+su público también (o en su lugar) aprende Y.
 Por ejemplo,
-quien enseña podría tener la intención de demostrar a sus estudiantes como buscar direcciones de correo electrónico en un archivo de texto,
-pero lo que su audiencia podría terminar aprendiendo son algunos atajos de teclado.
+quien enseña podría tener la intención de demostrar a sus estudiantes cómo buscar direcciones de correo electrónico en un archivo de texto,
+pero lo que su público podría terminar aprendiendo son algunos atajos de teclado.
 
 \seclbl{Dando y recibiendo retroalimentación al enseñar}{s:performance-feedback}
 
@@ -457,7 +457,7 @@ Si solicitas una retroalimentación:
 
 \begin{description}
 
-\item[Iniciala.]
+\item[Iníciala.]
   Es mejor pedir la retroalimentación que recibirla de mala gana.
 
 \item[Elige tus preguntas,]
@@ -471,7 +471,7 @@ Si solicitas una retroalimentación:
   Direccionar la retroalimentación de esta manera además es más útil para ti.
   Siempre es preferible mejorar una cosa a la vez
   que cambiar todo y esperar que sea para mejor.
-  Direccionar los comentarios hacia algo que elegiste trabajar ayuda a mantenerte enfocado/a,
+  Direccionar los comentarios hacia algo que elegiste trabajar ayuda a mantenerte en foco,
   lo que a su vez aumenta las chances de que veas un progreso.
 
 \item[Usa un traductor de retroalimentación.]
@@ -479,10 +479,10 @@ Si solicitas una retroalimentación:
   Puede ser más fácil escuchar,
   ``Varias personas piensan que podrías acelerar un poco,''
   que leer varias notas que digan, ``Esto es demasiado lento''
-  o, ``Esto es aburrido.''
+  o ``Esto es aburrido.''
 
 \item[Sé amable contigo.]
-  Muchos/as de nosotros/as somos muy críticos/as con nosotros/as mismos/as,
+  La mayoría somos muy críticos/as con nosotros/as mismos/as,
   por lo que siempre es útil anotar lo que pensamos de nosotros/as
   \emph{antes} de recibir retroalimentación de otras personas.
   Eso nos permite comparar lo que pensamos de nuestro desempeño
@@ -490,8 +490,8 @@ Si solicitas una retroalimentación:
   lo que a su vez nos permite evaluar esto último con mayor precisión.
   Por ejemplo,
   es muy común que las personas piensen que están diciendo ``mmm'' y ``ehh'' con demasiada frecuencia
-  cuando tu audiencia en realidad no lo nota.
-  Recibir esa retroalimentación una vez permite a los/as docentes ajustar la evaluación sobre si mismos/as la próxima vez que se sientan así.
+  cuando tu público en realidad no lo nota.
+  Recibir esa retroalimentación una vez permite a los/las docentes ajustar la evaluación sobre sí mismos/as la próxima vez que se sientan así.
 
 \end{description}
 
@@ -504,7 +504,7 @@ También puedes dar retroalimentación a otras personas de manera más efectiva:
 \item[Interactúa.]
   Mirar fijamente a alguien es una buena manera de hacer que se sienta incómodo/a,
   por lo que si deseas darle una retroalimentación sobre cómo enseña normalmente,
-  necesitas tranquilizarlo/a.
+  necesitas ayudar a que se tranquilice.
   Interactuar con la persona como si fueras estudiante es una buena manera de hacer esto,
   así que haz preguntas o simula escribir su ejemplo.
   Si eres parte de un grupo,
@@ -516,7 +516,7 @@ También puedes dar retroalimentación a otras personas de manera más efectiva:
   uno negativo,
   y un segundo positivo
   se vuelve agotador rápidamente,
-  pero es importante decirle a las personas que deben seguir haciendo
+  pero es importante decirle a las personas qué deben seguir haciendo
   y qué deben cambiar\footnote{
     Por un tiempo,
     me preocupé tanto por la afinación que perdí completamente mi sentido del tiempo
@@ -526,7 +526,7 @@ También puedes dar retroalimentación a otras personas de manera más efectiva:
   No vas a recordar todo lo que notaste
   si la presentación dura más de unos pocos segundos,
   y definitivamente no vas a recordar con qué frecuencia lo notaste.
-  Escribe una nota la primera vez que algo sucede
+  Escribe una nota la primera vez que algo suceda
   y luego agrega una marca o cruz cuando vuelva a ocurrir
   para que puedas ordenar tus comentarios por frecuencia.
 
@@ -570,7 +570,7 @@ mientras que~\cite{Gawa2011} analiza el valor de tener un/a tutor/a.
   y reciben devoluciones de sus pares en ese mismo momento.
   Estas clases son más efectivas cuando el/la docente evalúa las devoluciones de pares
   para que quienes participen aprendan no solo cómo construir edificios
-  sino también como dar y recibir retroalimentación~\cite{Scho1984}.
+  sino también cómo dar y recibir retroalimentación~\cite{Scho1984}.
   Las clases magistrales de música tienen un propósito similar,
   y he descubierto que dar retroalimentación sobre la retroalimentación
   ayuda a las personas a mejorar su manera de enseñar también.
@@ -578,7 +578,7 @@ mientras que~\cite{Gawa2011} analiza el valor de tener un/a tutor/a.
 
 \seclbl{¿Cómo practicar cómo enseñamos?}{s:performance-practice}
 
-La mejor manera de perfecccionar la forma en que damos clases en persona es observarse a sí mismo hacerlo:
+La mejor manera de perfecccionar la forma en que damos clases en persona es observarse a sí mismo/a hacerlo:
 
 \begin{itemize}
 
@@ -586,21 +586,21 @@ La mejor manera de perfecccionar la forma en que damos clases en persona es obse
   Trabaja en grupos de a tres personas.
 
 \item
-  Cada persona rota entre los roles de docente, audiencia y quien graba.
+  Cada persona rota entre los roles de docente, público y quien graba.
   La persona en el rol docente tiene 2 minutos para explicar algo.
-  La persona que pretende ser la audiencia está allí para prestar atención,
+  La persona que pretende ser el público está allí para prestar atención,
   mientras que la tercera persona graba la sesión con un teléfono u otro dispositivo portátil.
 
 \item
   Luego de que todas las personas tuvieron la oportunidad de enseñar,
   el grupo mira todos los videos.
-  Cada persona da una retroalimentación sobre los 3 videos,
+  Cada persona da una retroalimentación sobre los tres videos,
   es decir, las personas dan una devolución sobre sí mismas y sobre las demás.
  
 \item
   Después de que se discutieron los videos,
   se borran.
-  (Muchas personas se sienten justificadamente incómodas por su aparición en Internet.)
+  (Muchas personas se sienten justificadamente incómodas por su aparición en internet.)
 
 \item
   Finalmente,
@@ -615,7 +615,7 @@ Para que este ejercicio funcione bien:
 \begin{itemize}
 
 \item
-  Graben los 3 videos y luego miren los 3.
+  Graben los tres videos y luego miren los tres.
   Si el ciclo es enseñar-revisar-enseñar-revisar,
   la última persona en enseñar siempre se queda sin tiempo
   (a veces a propósito).
@@ -632,15 +632,15 @@ Para que este ejercicio funcione bien:
 \item
   Los grupos deben estar físicamente separados para reducir el ruido en sus grabaciones.
   En la práctica,
-  esto significa 2--3 grupos en un aula de tamaño normal,
+  esto significa 2--3 grupos en un aula de tamaño normal
   y el resto usando espacios de descanso cercanos, oficinas
-  o (en una ocasión) el armario de conserje.
+  o (en una ocasión) el armario de la conserjería.
 
 \item
   Las personas deben dar retroalimentación sobre sí mismas y entre sí
   para que puedan calibrar sus impresiones de la manera en que enseñan
   contra las de otras personas.
-  La mayoría de las personas son más críticas sobre ellas mismas de lo que deberían ser,
+  La mayoría de las personas son más críticas sobre ellas mismas de lo que deberían ser
   y es importante que se den cuenta de esto.
 
 \end{itemize}
@@ -657,9 +657,9 @@ y tienen una rúbrica compartida para definir expectativas.
 Y hablando de rúbricas:
 una vez que la clase haya puesto todos sus comentarios en una grilla compartida,
 elige algunos comentarios positivos y negativos.
-haz una lista,
+haz una lista
 y pídeles que hagan el ejercicio nuevamente.
-La mayoría de las personas se sienten más cómodas la segunda vez,
+La mayoría de las personas se sienten más cómodas la segunda vez
 y la evaluación sobre lo que han decidido que es importante aumenta su sentido de autodeterminación (\chapref{s:motivation}).
 
 \begin{aside}{Tics}
@@ -667,7 +667,7 @@ y la evaluación sobre lo que han decidido que es importante aumenta su sentido 
   hablamos más rápido y con voz más aguda de lo normal cuando estamos en el escenario,
   jugamos con nuestro pelo,
   o hacemos sonar los nudillos.
-  Las personas que juegan llaman a esto ``tics,''
+  Las personas que juegan llaman a esto ``tics''
   y a menudo no se dan cuenta de que se mueven,
   se miran los zapatos,
   o juegan con lo que tienen en los bolsillos
@@ -696,9 +696,9 @@ sin duplicar ningún comentario.
 \exercise{Practicar dar devoluciones}{grupos pequeños}{45'}
 
 Usa el proceso descripto en la \secref{s:performance-practice}
-para enseñar en grupos de 3 y recolectar las devoluciones.
+para enseñar en grupos de tres personas y recolectar las devoluciones.
 
-\exercise{Lo malo y lo bueno}{toda la clase}{20}
+\exercise{Lo malo y lo bueno}{toda la clase}{20'}
 
 Mira los videos de \hreffoot{https://youtu.be/bXxBeNkKmJE}{programación en vivo mal desarrollada}
 y \hreffoot{https://youtu.be/SkPmwe\_WjeY}{bien desarrollada}
@@ -708,7 +708,7 @@ y resume tu devolución sobre las diferencias usando la grilla 2x2 habitual.
 
 \exercise{Observa, luego hace}{parejas}{30'}
 
-Enseña 3--4 minutos de una lección usando programación en vivo a un/a colega,
+Enseña a tu pareja 3--4 minutos de una lección usando programación en vivo,
 luego intercambien lugares y observa a esa persona programar en vivo.
 No te preocupes por grabar estas sesiones---es difícil capturar tanto a la persona como a la pantalla con un dispositivo portátil---pero
 da una devolución de la misma manera que lo hiciste antes.
@@ -749,14 +749,14 @@ Explícales a tus colegas qué vas a enseñar y con qué esperas que estén fami
   Enseña una clase corta (de 2--3 minutos).
 
 \item
-  Pregúntale a tu audiencia cómo creen que te traicionan los nervios.
+  Pregúntale a tu público cómo creen que te traicionan los nervios.
   ¿Coinciden con lo que pensaste de ti?
 
 \end{enumerate}
 
 \exercise{Consejos para enseñar}{grupos pequeños}{15'}
 
-El sitio \hreffoot{http://csteachingtips.org/}{CS Teaching Tips}
+El sitio \hreffoot{http://csteachingtips.org/}{CS Teaching Tips} (en inglés)
 tiene una gran cantidad de consejos prácticos sobre cómo enseñar computación,
 así como una colección de hojas de consejos descargables.
 Revisa las hojas de consejos en grupos pequeños y clasifica cada uno


### PR DESCRIPTION
**Revisión de performance.tex**
Hice pocas correcciones, la mayoría muy menores

- Cambié el subtítulo para evitar `/` en un título:
\subsection*{Ser visto/a y escuchado/a}
por
\subsection*{Visible y con voz clara}

- Quito la sigla ED, se usa poco


**Dudas y sugerencias**

- _LISTO: A qué se refiere? (tortuga (?)) (parece bien la traducción!): ``Usemos tortuga punto `r' `i' y Tab para completar con `right'.''_

- El mapa conceptual de resumen usa "devolución" (en la figura), mientras que tanto en la figura como a lo largo del texto se usa "retroalimentación". Cambiaría "devolución" en la figura.

- Sugerencia: cambiar los videos de buena y mala enseñanza por otros en castellano. Los del taller de Carpentries coordinado por Metadocencia? Alternativa: subtitular los que hay en el link. 