### PR TITLE
Temporal fix of Latex labels for the Spanish html & pdf versions

### DIFF
--- a/tex/html-settings.tex
+++ b/tex/html-settings.tex
@@ -32,6 +32,15 @@
 \newcommand{\figref}[1]{Figure~\ref{#1}}
 \newcommand{\secref}[1]{Section~\ref{#1}}
 
+% Chapters, sections, and appendices with labels. Spanish version
+%\newcommand{\chaplbl}[2]{\chapter{#1}\label{#2}}
+%\newcommand{\seclbl}[2]{\section{#1}\label{#2}}
+%\newcommand{\appref}[1]{Anexo~\ref{#1}}
+%\newcommand{\chapref}[1]{Capítulo~\ref{#1}}
+%\newcommand{\figref}[1]{Figura~\ref{#1}}
+%\newcommand{\secref}[1]{Sección~\ref{#1}}
+
+
 % Image figures.
 \newcommand{\figimg}[3]{\begin{figure}%
 \centering%

--- a/tex/pdf-settings.tex
+++ b/tex/pdf-settings.tex
@@ -126,6 +126,14 @@
 \newcommand{\figref}[1]{Figure~\ref{#1}}
 \newcommand{\secref}[1]{Section~\ref{#1}}
 
+% Chapters, sections, and appendices with labels. Spanish version
+%\newcommand{\chaplbl}[2]{\chapter{#1}\label{#2}}
+%\newcommand{\seclbl}[2]{\section{#1}\label{#2}}
+%\newcommand{\appref}[1]{Anexo~\ref{#1}}
+%\newcommand{\chapref}[1]{Capítulo~\ref{#1}}
+%\newcommand{\figref}[1]{Figura~\ref{#1}}
+%\newcommand{\secref}[1]{Sección~\ref{#1}}
+
 % Image figures.
 \newcommand{\figimg}[3]{\begin{figure}%
 \centering%


### PR DESCRIPTION
I added some lines in the pdf-settings and html-settings, that are now commented.
If uncommented (and commenting the original _% Chapters, sections, and appendices with labels._), the compiled file has labels in Spanish.

```
% Chapters, sections, and appendices with labels. Spanish version
%\newcommand{\chaplbl}[2]{\chapter{#1}\label{#2}}
%\newcommand{\seclbl}[2]{\section{#1}\label{#2}}
%\newcommand{\appref}[1]{Anexo~\ref{#1}}
%\newcommand{\chapref}[1]{Capítulo~\ref{#1}}
%\newcommand{\figref}[1]{Figura~\ref{#1}}
%\newcommand{\secref}[1]{Sección~\ref{#1}}

```

It's a temporal fix because the actual fix would be to have a conditional that detects the language (maybe according to the folder where the make is run), but I don't know how to do it.
