### PR TITLE
exercises.tex 1st revision - Spanish version

### DIFF
--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -492,7 +492,7 @@ Muchos tipos de ejercicios de programación son difíciles de evaluar por los/la
 Las clases van desarrollándose con vistas a proyectos de programación mayores (si todo va bien), 
 pero la única manera de dar retroalimentación es caso por caso.
 La \emph{revisión de código} también es, en general, difícil de calificar automáticamente,
-pero puede ser abordada si se proporciona a  los/las estudiantes una lista de fallos a buscar y se les pide que comparen comentarios con líneas de código concretas.
+pero puede ser abordada si se proporciona a los/las estudiantes una lista de fallos a buscar y se les pide que comparen comentarios con líneas de código concretas.
 
 Por ejemplo, 
 se le puede decir a un/a estudiante que hay dos errores de sangría y un nombre de variable incorrecto y se le puede pedir que los señale.

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -226,7 +226,7 @@ contribuyen a que los/las estudiantes desarrollen habilidades valiosas de depura
 valores = [ [1.0, -0.5], [3.0, 1.5], [2.5, ___] ]
 corridaTotal = 0.0
 for (lectura, escalada) in valores:
-    runningTotal += reading / scaling
+    corridaTotal += lectura / escalada
 \end{minted}
 \end{aside}
 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -436,7 +436,7 @@ la gran mayoría de los/las estudiantes optaron por validar su comprensión de l
 antes de intentar resolver los problemas, 
 y así hicieron menos preguntas y expresaron menos confusión acerca de las tareas.
 
-\begin{aside}{Contra herramientas disponibles en el mercado}
+\begin{aside}{En contra de las herramientas ``listas para usar" disponibles en el mercado}
 Es tentador usar herramientas de revisión de estilo fácilmente disponibles para calificar el código de los/las estudiantes.
 Sin embargo,
 \cite{Nutb2016} inicialmente no encontraron correlación entre las calificaciones proporcionadas por personas 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -545,7 +545,7 @@ y mira cuántas entradas diferentes que satisfagan los requisitos puede encontra
 
 Escribe un programa corto (10-15 líneas),
  intercambia con tu pareja y 
-traza cómo las variables del programa cambian de valor con el tiempo.
+sigue cómo las variables del programa cambian de valor con el tiempo.
 ¿Qué diferencias hay en la forma en que tú y tu pareja escribieron sus trazas?
 
 \exercise{Refactorizar}{grupos pequeños}{15’}

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -310,7 +310,7 @@ for v in values:
 \seclbl{Diagramas}{s:exercises-diagrams}
 
 Hacer que los estudiantes dibujen mapas conceptuales y otros diagramas brinda una idea de cómo están pensando (\secref{s:memory-concept-maps}),
-pero los diagramas de forma libre requieren tiempo y juicio humano para evaluarlos.
+pero los diagramas de forma libre requieren que una persona los evalúe (no pueden ser calificados automáticamente), por lo que consumen mucho tiempo.
 
 \emph{Etiquetar los diagramas},
 por otra parte, 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -54,7 +54,7 @@ esta pregunta de opción múltiple sólo puede ser contestada ejecutando el coma
   \item
     \texttt{otonio.csv}
   \item
-    \texttt{otono.csv}
+    \texttt{verano.csv}
   \item
     \texttt{primavera.csv}
   \item

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -422,7 +422,7 @@ que los/las autores atribuyen a la calidad de los mensajes de retroalimentación
 \cite{Srid2016} adoptaron un enfoque diferente.
 Utilizaron \gref{g:fuzz-testing}{fuzz testing} 
 (casos de prueba generados aleatoriamente) 
-para comprobar si el código del estudiante realiza lo mismo que una implementación de referencia proporcionada por el profesor.
+para comprobar si el código del estudiante realiza lo mismo que una implementación de referencia proporcionada por el/la docente.
 En el primer proyecto de un curso introductorio de 1400 estudiantes y estudiantes, el fuzz testing identificó errores que no habían sido detectados en un conjunto de casos de prueba escritos a mano para más del 48\% de los estudiantes.
 
 \cite{Basu2015} dio a sus estudiantes una serie de soluciones a casos de prueba, 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -449,7 +449,7 @@ pero otras veces se debía a que enviaban el código de inicio de tarea con poca
    \cite{Keun2016a,Keun2016b} observaron los mensajes producidos por 69 herramientas de calificación automática.
   Encontraron que estas herramientas a menudo no dan retroalimentación sobre cómo solucionar problemas y dar el siguiente paso.
     También encontraron que la mayoría de los/las docentes no pueden adaptar fácilmente la mayoría de las herramientas a sus necesidades: 
-como muchas herramientas de flujo de trabajo, tienden a hacer cumplir supuestos no reconocidos por sus creadores sobre cómo funcionan las instituciones.
+como muchas herramientas de flujo de trabajo, tienden a hacer cumplir los supuestos no reconocidos de sus creadores sobre cómo funcionan las instituciones.
   Su esquema de clasificación es una lista de compras útil cuando se examinan herramientas de este tipo.
 \end{aside}
 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -537,7 +537,7 @@ y analiza cuánto tiempo les toma a cada uno de ustedes entender y hacer el ejer
 \exercise{Invertir el código y la ejecución}{grupos pequeños}{15’}
 
 Forma grupos de 4 a 6 personas.
-Haz que cada integrante del grupo cree un ejercicio de \emph{programar y ejecutar} invertido que requiera que las personas averigüen qué entrada produce una salida en particular.
+Haz que cada integrante del grupo cree un ejercicio de \emph{programar y ejecutar} invertido: el ejercicio debe requerir que las personas averigüen qué entrada produce una salida en particular.
 Elige dos ejercicios al azar 
 y mira cuántas entradas diferentes que satisfagan los requisitos puede encontrar el grupo.
 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -480,7 +480,7 @@ es frustante decirles a los/las estudiantes que se han equivocado pero no decirl
 Una tercera opción es utilizar una técnica llamada \gref{g:hashing}{\emph{hashing}} para generar un valor que depende de la salida pero sin revelarla.
 
 Si el/la usuario/a produce exactamente el resultado correcto
-entonces su hash desbloqueará la solución, 
+entonces su \emph{hash} desbloqueará la solución, 
 pero es imposible hacer el camino inverso a partir del hash para averiguar cuál se supone que es la salida.
 
 El hashing requiere más trabajo y explicación para configurarlo, 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -216,7 +216,7 @@ También puedes requerir que  los/las estudiantes rastreen el código hacia atr�
 
 Estos problemas de  \emph{ejecución inversa} requieren razonamientos de búsqueda y deducción, 
 y cuando la salida es un mensaje de error, 
-ayudan a los/las estudiantes a desarrollar habilidades valiosas de depuración.
+contribuyen a que los/las estudiantes desarrollen habilidades valiosas de depuración.
 
 \begin{aside}{Ejecución inversa}
   Rellena el número faltante en \texttt{valores}

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -74,7 +74,7 @@ Hacer esto les ayuda a descubrir si han malinterpretado completamente la intenci
 
 En lugar de escribir código que satisface algunas especificaciones,  
 se les puede pedir a los/las estudiantes que escriban pruebas para determinar si un fragmento de código se ajusta a una especificación. 
-Esta es una habilidad útil por sí misma y hacerlo puede darles a los/las estudiantes un poco más de simpatía por lo duro que trabajan sus docentes.
+Esta habilidad es útil por sí misma y practicarla puede darles a los/las estudiantes un poco más de simpatía por el trabajo duro de sus docentes.
 
 \begin{aside}{Invirtiendo programar \& ejecutar}
  La función \texttt{monotonic\_sum} calcula la suma de cada sección de una lista de números, en la que los valores aumentan estrictamente.

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -488,7 +488,7 @@ pero logra un buen balance entre revelar respuestas prematuramente  y no revelar
 
 \seclbl{Razonamientos de alto nivel}{s:exercises-higher}
 
-Muchos tipos de ejercicios de programación son difíciles de evaluar por docentes en una clase con más de un puñado de estudiantes e igualmente difícil para evaluar mediante plataformas automatizadas.
+Muchos tipos de ejercicios de programación son difíciles de evaluar por los/las docentes en una clase con más de un puñado de estudiantes y son igualmente difíciles de evaluar mediante plataformas automatizadas.
 Las clases van desarrollándose con vistas a proyectos de programación mayores (si todo va bien), 
 pero la única manera de dar retroalimentación es caso por caso.
 La \emph{revisión de código} también es, en general, difícil de calificar automáticamente,

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -1,6 +1,6 @@
 \chapter{Tipos de ejercicios}\label{s:exercises}
 
-Todo/a buen/a carpintero/a tiene un juego de destornilladores y todo/a buen/a docente tiene diferentes tipos de ejercicios para comprobar qué están aprendiendo realmente los/las estudiantes, para ayudarlos a practicar sus nuevas habilidades y para mantener su  compromiso.
+Todo/a buen/a carpintero/a tiene un juego de destornilladores y todo/a buen/a docente tiene diferentes tipos de ejercicios para comprobar qué están aprendiendo realmente los/las estudiantes, para ayudarlos a practicar sus nuevas habilidades y para mantener su compromiso.
 
 Este capítulo comienza describiendo varios tipos de ejercicios que se pueden usar para corroborar si tu forma de enseñar ha resultado efectiva.
 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -43,7 +43,7 @@ crea una versión blanco y negro de la imagen
 y asígnala a una variable nueva llamada \texttt{monocromo}.
 \end{aside}
 
-Los ejercicios de escritura y ejecución se pueden combinar con preguntas de opción múltiple.
+Los ejercicios de programar y ejecutar se pueden combinar con preguntas de opción múltiple.
 Por ejemplo,
 esta pregunta de opción múltiple sólo puede ser contestada ejecutando el comando Unix \texttt{ls}:
 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -76,7 +76,7 @@ En lugar de escribir código que satisface algunas especificaciones,
 se les puede pedir a los/las estudiantes que escriban pruebas para determinar si un fragmento de código se ajusta a una especificación. 
 Esta habilidad es útil por sí misma y practicarla puede darles a los/las estudiantes un poco más de simpatía por el trabajo duro de sus docentes.
 
-\begin{aside}{Invirtiendo programar \& ejecutar}
+\begin{aside}{Invirtiendo programar y ejecutar}
  La función \texttt{monotonic\_sum} calcula la suma de cada sección de una lista de números, en la que los valores aumentan estrictamente.
 
 Por ejemplo,

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -481,7 +481,7 @@ Una tercera opción es utilizar una técnica llamada \gref{g:hashing}{\emph{hash
 
 Si el/la usuario/a produce exactamente el resultado correcto
 entonces su \emph{hash} desbloqueará la solución, 
-pero es imposible hacer el camino inverso a partir del hash para averiguar cuál se supone que es la salida.
+pero es imposible hacer el camino inverso a partir del \emph{hash} para averiguar cuál se supone que es la salida.
 
 El hashing requiere más trabajo y explicación para configurarlo, 
 pero logra un buen balance entre revelar respuestas prematuramente  y no revelarlas cuando podría ser de ayuda.

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -49,7 +49,7 @@ esta pregunta de opción múltiple sólo puede ser contestada ejecutando el coma
 
 \begin{aside}{Combinar preguntas de opción múltiple con programar \& ejecutar}
   Estás en el directorio  \texttt{/home}.
-  ¿Cuál de los siguientes archivos está\emph{no está} en dicho directorio?
+  ¿Cuál de los siguientes archivos \emph{no está} en dicho directorio?
   \begin{enumerate}
   \item
     \texttt{otonio.csv}

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -225,7 +225,7 @@ contribuyen a que los/las estudiantes desarrollen habilidades valiosas de depura
 \begin{minted}{text}
 valores = [ [1.0, -0.5], [3.0, 1.5], [2.5, ___] ]
 corridaTotal = 0.0
-for (reading, scaling) in valores:
+for (lectura, escalada) in valores:
     runningTotal += reading / scaling
 \end{minted}
 \end{aside}

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -36,7 +36,7 @@ Generalmente es suficiente pedir a las personas principiantes que calculen e imp
 docentes experimentados/as a menudo olvidan de lo difícil que puede ser averiguar qué parámetros van en qué lugar.
 Para los/las estudiantes  más avanzados, averiguar qué función llamar es una actividad más atractiva y una mejor evaluación de su comprensión.
 
-\begin{aside}{Programa \& ejecuta}
+\begin{aside}{Programar y ejecutar}
 La variable \texttt{foto} contiene una imagen a todo color de un archivo.
 Usando una función,
 crea una versión blanco y negro de la imagen

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -111,7 +111,7 @@ las respuestas enviadas son mucho más predecibles y, por lo tanto, más fácile
 
 \begin{aside}{Completar los espacios en blanco}
  Completa los espacios en blanco,
- para que el código de abajo imprima el texto  \texttt{'sombrero'}.
+ para que el código de abajo imprima el texto  \texttt{'cana'}.
 
 \begin{minted}{text}
 text = 'todo lo que es'

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -65,7 +65,7 @@ esta pregunta de opción múltiple sólo puede ser contestada ejecutando el coma
 Los ejercicios de programar y ejecutar ayudan a las personas a practicar las habilidades que más quieren aprender,
 pero pueden ser  difíciles de evaluar:
 puede haber muchas maneras inesperadas de obtener la respuesta correcta,
-y la gente se desmoralizará si un sistema de calificación automática rechaza su código porque no se corresponde con el del docente.
+y es desmoralizante si un sistema de calificación automática rechaza el código de la solución porque no se corresponde con el del docente.
 Una forma de reducir la frecuencia con la que esto ocurre es evaluar solo su producción,
 pero eso no les da una devolución sobre cómo están programando.
 Otra manera es darles un pequeño conjunto de evaluación en el que pueden ejecutar su código antes de enviarlo

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -235,7 +235,7 @@ Los ejercicios de \emph{ajuste mínimo} también ayudan a desarrollar habilidade
 
 Dadas unas pocas líneas de código que contienen un error, el/la estudiante deben encontrarlo y hacer un pequeño cambio para arreglarlo.
 
-El cambio puede hacerse usando \emph{programa y ejecuta},
+El cambio puede hacerse usando \emph{programar y ejecutar},
 mientras que la identificación se puede hacer como una pregunta de opción múltiple.
 
 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -450,7 +450,7 @@ pero otras veces se debía a que enviaban el código de inicio de tarea con poca
   Encontraron que estas herramientas a menudo no dan retroalimentación sobre cómo solucionar problemas y dar el siguiente paso.
     También encontraron que la mayoría de los/las docentes no pueden adaptar fácilmente la mayoría de las herramientas a sus necesidades: 
 como muchas herramientas de flujo de trabajo, tienden a hacer cumplir los supuestos no reconocidos de sus creadores sobre cómo funcionan las instituciones.
-  Su esquema de clasificación es una lista de compras útil cuando se examinan herramientas de este tipo.
+  Tu esquema de clasificación es una buena lista de requisitos para chequear cuando se examinan herramientas de este tipo.
 \end{aside}
 
 \cite{Buff2015} presenta una reflexión bien documentada sobre la idea de proporcionar una retroalimentación automatizada.

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -539,7 +539,7 @@ y analiza cuánto tiempo les toma a cada uno de ustedes entender y hacer el ejer
 Forma grupos de 4 a 6 personas.
 Haz que cada integrante del grupo cree un ejercicio de \emph{programar y ejecutar} invertido que requiera que las personas averigüen qué entrada produce una salida en particular.
 Elige dos ejercicios al azar 
-y mira cuántas entradas diferentes que satisfagan los requisitos puede encontrar el grupo .
+y mira cuántas entradas diferentes que satisfagan los requisitos puede encontrar el grupo.
 
 \exercise{Siguiendo valores}{parejas}{10’}
 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -537,7 +537,7 @@ y analiza cuánto tiempo les toma a cada uno de ustedes entender y hacer el ejer
 \exercise{Invertir el código y la ejecución}{grupos pequeños}{15’}
 
 Forma grupos de 4 a 6 personas.
-Haz que cada integrante del grupo cree un ejercicio de \emph{programa y ejecuta} invertido que requiera que las personas averigüen qué entrada produce una salida en particular.
+Haz que cada integrante del grupo cree un ejercicio de \emph{programar y ejecutar} invertido que requiera que las personas averigüen qué entrada produce una salida en particular.
 Elige dos ejercicios al azar 
 y mira cuántas entradas diferentes que satisfagan los requisitos puede encontrar el grupo .
 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -261,7 +261,7 @@ en lugar de realizar un cambio para corregir un error.
 Los cambios permitidos pueden incluir cambiar el valor inicial de una variable, 
 reemplazar una llamada a una función por otra, 
 intercambiar bucles internos y externos,
-o cambiar el orden de las pruebas en un condicional complejo
+o cambiar el orden de las pruebas en un condicional complejo.
 
 De nuevo,
 este tipo de ejercicio da a los/las estudiantes la oportunidad de practicar una habilidad útil para el mundo real:

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -497,7 +497,7 @@ pero puede ser abordada si se proporciona a  los/las estudiantes una lista de fa
 Por ejemplo, 
 se le puede decir a un/a estudiante que hay dos errores de sangría y un nombre de variable incorrecto y se le puede pedir que los señale.
 
-Si son estudiantes/as más avanzados/as, se les podría dar media docena de tipos de comentarios que podrían hacerse sobre el código sin que se les diga cuánto de cada uno debería encontrar.
+Si son estudiantes/as más avanzados/as, se les podría dar media docena de tipos de comentarios que podrían hacerse sobre el código sin que se les diga cuántos de cada tipo deberían encontrar.
 
 \cite{Steg2016b} es un buen punto de partida para una rúbrica de estilo de código, mientras que~\cite{Luxt2009} muestra la revisión por pares en las clases de programación de manera más general.
 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -1,6 +1,6 @@
 \chapter{Tipos de ejercicios}\label{s:exercises}
 
-Todo buen carpintero tiene un juego de destornilladores y todo buen docente tiene diferentes tipos de ejercicios para comprobar qué están aprendiendo realmente los/las estudiantes, para ayudarlos a practicar sus nuevas habilidades, y para mantener su  compromiso.
+Todo/a buen/a carpintero/a tiene un juego de destornilladores y todo/a buen/a docente tiene diferentes tipos de ejercicios para comprobar qué están aprendiendo realmente los/las estudiantes, para ayudarlos a practicar sus nuevas habilidades y para mantener su  compromiso.
 
 Este capítulo comienza describiendo varios tipos de ejercicios que se pueden usar para corroborar si tu forma de enseñar ha resultado efectiva.
 
@@ -10,12 +10,12 @@ Nuestra discusión se basa parcialmente en el Banco de Preguntas de Canterbury \
 
 \seclbl{Los clásicos}{s:exercises-classics}
 
-Como se discute en \secref{s:models-formative-assessment}, las \emph{preguntas de opción múltiple} (\emph{MCQ} por sus siglas en Inglés)  son más efectivas cuando las respuestas incorrectas sondean conceptos erróneos específicos.  
-Están designadas para evaluar los niveles más bajos en la \index{Bloom's Taxonomy}
-(\secref{s:process-objectives}) ,pero también puede requerir que los/las estudiantes utilicen su propio juicio/criterio.
+Como se discute en \secref{s:models-formative-assessment}, las \emph{preguntas de opción múltiple} son más efectivas cuando las respuestas incorrectas sondean conceptos erróneos específicos.  
+Están diseñadas para evaluar los niveles más bajos en la Taxonomía de Bloom \index{Taxonomía de Bloom}
+(\secref{s:process-objectives}), pero también requieren que los/las estudiantes utilicen su propio juicio.
 
 \begin{aside}{Una pregunta de opción múltiple}
-  En qué orden ocurren las operaciones cuando la computadora evalúa la expresión \texttt{precio\ =\ agregarImpuestos(costo\ -\ descuento)}?
+  ¿En qué orden ocurren las operaciones cuando la computadora evalúa la expresión \texttt{precio\ =\ agregarImpuestos(costo\ -\ descuento)}?
   \begin{enumerate}
   \item
     resta, llamado a función, asignación
@@ -29,40 +29,40 @@ Están designadas para evaluar los niveles más bajos en la \index{Bloom's Taxon
 \end{aside}
 
 
-El segundo tipo de ejercicio de programación clásico es \emph{codificar y ejecutar} (\emph{C\&R}, por sus siglas en inglés),
-donde el estudiante escribe un código que produce una salida especificada. 
-Los ejercicios \emph{C\&R} pueden ser tan simples o complejos como el docente o la docente quiera, pero cuando se usen en clase deben ser breves y tener solo una o dos respuestas correctas posibles.
+El segundo tipo de ejercicio clásico es \emph{programar y ejecutar},
+donde el/la estudiante escribe un código que produce una salida especificada. 
+Los ejercicios de programar y ejecutar pueden ser tan simples o complejos como el/la docente quiera, pero cuando se usen en clase deben ser breves y tener solo una o dos respuestas correctas posibles.
 Generalmente es suficiente pedir a las personas principiantes que calculen e impriman un solo valor o que llamen a una función específica:
-docentes experimentados a menudo olvidan de lo difícil que puede ser averiguar qué parámetros van en qué lugar.
-Para los/las estudiantes  más avanzados, averiguar qué función llamar, es una actividad más atractiva y una mejor evaluación de su comprensión.
+docentes experimentados/as a menudo olvidan de lo difícil que puede ser averiguar qué parámetros van en qué lugar.
+Para los/las estudiantes  más avanzados, averiguar qué función llamar es una actividad más atractiva y una mejor evaluación de su comprensión.
 
 \begin{aside}{Programa \& ejecuta}
-La variable \texttt{picture}contiene una imagen a todo color de un archivo.
+La variable \texttt{foto} contiene una imagen a todo color de un archivo.
 Usando una función,
 crea una versión blanco y negro de la imagen
-y asígnala a una variable nueva llamada \texttt{monochrome}.
+y asígnala a una variable nueva llamada \texttt{monocromo}.
 \end{aside}
 
 Los ejercicios de escritura y ejecución se pueden combinar con preguntas de opción múltiple.
 Por ejemplo,
-estas preguntas de opción múltiple sólo puede ser contestada ejecutando el comando Unix \texttt{ls}:
+esta pregunta de opción múltiple sólo puede ser contestada ejecutando el comando Unix \texttt{ls}:
 
 \begin{aside}{Combinar preguntas de opción múltiple con programar \& ejecutar}
   Estás en el directorio  \texttt{/home}.
   ¿Cuál de los siguientes archivos está\emph{no está} en dicho directorio?
   \begin{enumerate}
   \item
-    \texttt{autumn.csv}
+    \texttt{otonio.csv}
   \item
-    \texttt{fall.csv}
+    \texttt{otono.csv}
   \item
-    \texttt{spring.csv}
+    \texttt{primavera.csv}
   \item
-    \texttt{winter.csv}
+    \texttt{invierno.csv}
   \end{enumerate}
 \end{aside}
 
-Los ejercicios de C\&Rs ayudan a las personas a practicar las habilidades que más quieren aprender,
+Los ejercicios de programar y ejecutar ayudan a las personas a practicar las habilidades que más quieren aprender,
 pero pueden ser  difíciles de evaluar:
 puede haber muchas maneras inesperadas de obtener la respuesta correcta,
 y la gente se desmoralizará si un sistema de calificación automática rechaza su código porque no se corresponde con el del docente.
@@ -74,7 +74,7 @@ Hacer esto les ayuda a descubrir si han malinterpretado completamente la intenci
 
 En lugar de escribir código que satisface algunas especificaciones,  
 se les puede pedir a los/las estudiantes que escriban pruebas para determinar si un fragmento de código se ajusta a una especificación. 
-Esta es una habilidad útil por sí misma y hacerlo puede dar a los/las estudiantes un poco más de simpatía por lo duro que trabajan sus profesores.
+Esta es una habilidad útil por sí misma y hacerlo puede darles a los/las estudiantes un poco más de simpatía por lo duro que trabajan sus docentes.
 
 \begin{aside}{Invirtiendo programar \& ejecutar}
  La función \texttt{monotonic\_sum} calcula la suma de cada sección de una lista de números, en la que los valores aumentan estrictamente.
@@ -83,7 +83,7 @@ Por ejemplo,
   dada la entrada \texttt{[1,\ 3,\ 3,\ 4,\ 5,\ 1]},
   la salida es  \texttt{[4,\ 12,\ 1]}.
 
-Escribe y corre pruebas unitarias para determinar cuál de los siguientes errores está contenido en la función :
+Escribe y corre pruebas unitarias para determinar cuál de los siguientes errores está contenido en la función:
 
    \begin{itemize}
   \item
@@ -98,20 +98,20 @@ Escribe y corre pruebas unitarias para determinar cuál de los siguientes errore
 \end{aside}
 
 
-\emph{Llenar los espacios en blanco} es un refinamiento de \emph{C\&R}
+\emph{Llenar los espacios en blanco} es un refinamiento de \emph{programa y ejecuta}
 en el que el/la estudiante recibe el comienzo de un código y debe completarlo.
 
-(En la práctica, la mayoría de los ejercicios \emph{C\&R} son en realidad del tipo de llenar los espacios en blanco, porque el/la docente proporciona comentarios
-para recordarles a los estudiantes los pasos que deben seguir. 
+(En la práctica, la mayoría de los ejercicios \emph{programa y ejecuta} son en realidad del tipo de llenar los espacios en blanco, porque el/la docente proporciona comentarios
+para recordarles a sus estudiantes los pasos que deben seguir. 
 Las preguntas de este tipo son las bases para ejemplos desvanecidos;
-como se discute en \chapref{s:architecture},
+como se discute en el \chapref{s:architecture},
 las personas principiantes a menudo encuentran a este tipo de ejercicios  menos intimidante que escribir todo el código desde cero;
 y dado que el/la docente ha proporcionado la mayor parte de la estructura de la respuesta,
 las respuestas enviadas son mucho más predecibles y, por lo tanto, más fáciles de revisar.
 
 \begin{aside}{Completar los espacios en blanco}
  Completa los espacios en blanco,
- para que el código de abajo imprima el texto  \texttt{'hat'}.
+ para que el código de abajo imprima el texto  \texttt{'sombrero'}.
 
 \begin{minted}{text}
 text = 'todo lo que es'
@@ -120,7 +120,7 @@ print(slice)
 \end{minted}
 \end{aside}
 
-El problema de Parsons \index{Parsons Problem} también evitar el problema de la ``pantalla blanca del terror" a la vez que permite que los/las estudiantes se concentren en el flujo de control por separado del vocabulario \cite{Pars2006,Eric2015,Morr2016,Eric2017}.
+Los problemas de Parsons \index{Problemas de Parsons} también evitan el problema de la ``pantalla blanca del terror" a la vez que permite que los/las estudiantes se concentren en el flujo de control por separado del vocabulario \cite{Pars2006,Eric2015,Morr2016,Eric2017}.
 
 Existen herramientas para construir y hacer problemas de Parsons en línea~\cite{Ihan2011},
 pero pueden ser emuladas (aunque un poco torpemente) 
@@ -134,11 +134,11 @@ pidiendo a los/las estudiantes que reorganicen las líneas de código en un edit
 total = 0
 if v > 0
 total += v
-for v in values
+for v in valores
 \end{minted}
 \end{aside}
 
-Ten en cuenta que dar a los/las estudiantes más líneas de las que necesitan, o pedirles que reordenen algunas líneas y añadir algunas más, hace que los problemas de Parsons sean significativamente más difíciles~\cite{Harm2016}.
+Ten en cuenta que dar a los/las estudiantes más líneas de las que necesitan, o pedirles que reordenen algunas líneas y añadan algunas más, hace que los problemas de Parsons sean significativamente más difíciles~\cite{Harm2016}.
 
 \seclbl{Seguir}{s:exercises-tracing}
 
@@ -146,14 +146,14 @@ Ten en cuenta que dar a los/las estudiantes más líneas de las que necesitan, o
 dadas unas pocas líneas de código, 
 los/las estudiantes tienen que rastrear el orden en que se ejecutan esas líneas.
 
-Esta es una habilidad esencial de depuración\index{debugging}
+Esta es una habilidad esencial de depuración \index{depuración}
  y una buena manera de consolidar la comprensión de los/las estudiantes de los bucles, los condicionales y el orden de evaluación de las llamadas a funciones y  métodos.
 
 La forma más fácil de implementarlo es hacer que los/las estudiantes escriban una secuencia de pasos etiquetados.
 Hacer que elijan la secuencia correcta de un conjunto 
-(es decir, presentarla como un preguntas de opción múltiple) 
+(es decir, presentarla como una pregunta de opción múltiple) 
 añade carga cognitiva sin añadir valor, 
-ya que tienen que hacer todo el trabajo de averiguar  la secuencia correcta y luego buscarla en la lista de opciones.
+ya que tienen que hacer todo el trabajo de averiguar la secuencia correcta y luego buscarla en la lista de opciones.
 
 \begin{aside}{Seguir el orden de ejecución}
   ¿En qué orden se ejecutan las líneas etiquetadas en este bloque de código?
@@ -171,7 +171,7 @@ D)         pass
 
 \emph{Seguir los valores} es similar a trazar la ejecución, 
 pero en lugar de deletrear el orden en que se ejecuta el código, 
-el estudiante enumera los valores que una o más variables toman
+el/la estudiante enumera los valores que una o más variables toman
  a medida que se ejecuta el programa.
 
 Una forma de implementar esto es dar a cada estudiante una tabla 
@@ -181,20 +181,20 @@ y pedirles que completen los valores que las variables toman en dichas líneas.
 
 \newpage
 \begin{aside}{Seguir los valores}
-  ¿Qué valores toman \texttt{left} y \texttt{right} a medida que este programa se ejecuta?
+  ¿Qué valores toman \texttt{izquierda} y \texttt{derecha} a medida que este programa se ejecuta?
 
 \begin{minted}{text}
-A) left = 23
-B) right = 6
-C) while right:
-D)     left, right = right, left % right
+A) izquierda = 23
+B) derecha = 6
+C) while derecha:
+D)     izquierda, derecha = derecha, izquierda % derecha
 \end{minted}
 \end{aside}
 
 \begin{center}
 \begin{tabular}{|l|l|l|}
   \hline
-  Line & \texttt{left} & \texttt{right} \\
+  Line & \texttt{izquierda} & \texttt{derecha} \\
   \hline
   & & \\
   \hline
@@ -218,14 +218,14 @@ Estos problemas de  \emph{ejecución inversa} requieren razonamientos de búsque
 y cuando la salida es un mensaje de error, 
 ayudan a los/las estudiantes a desarrollar habilidades valiosas de depuración.
 
-\begin{aside}{Ejecución Reversa}
-  Rellena el número faltante en \texttt{values}
+\begin{aside}{Ejecución inversa}
+  Rellena el número faltante en \texttt{valores}
   que causó que esta función se interrumpiera.
 
 \begin{minted}{text}
-values = [ [1.0, -0.5], [3.0, 1.5], [2.5, ___] ]
+valores = [ [1.0, -0.5], [3.0, 1.5], [2.5, ___] ]
 runningTotal = 0.0
-for (reading, scaling) in values:
+for (reading, scaling) in valores:
     runningTotal += reading / scaling
 \end{minted}
 \end{aside}
@@ -233,9 +233,9 @@ for (reading, scaling) in values:
 
 Los ejercicios de \emph{ajuste mínimo} también ayudan a desarrollar habilidades de depuración.
 
-Dadas unas pocas líneas de código que contienen un error, el estudiante o la estudiante deben encontrarlo y hacer un pequeño cambio para arreglarlo.
+Dadas unas pocas líneas de código que contienen un error, el/la estudiante deben encontrarlo y hacer un pequeño cambio para arreglarlo.
 
-El cambio puede hacerse usando C\&R,
+El cambio puede hacerse usando \emph{programa y ejecuta},
 mientras que la identificación se puede hacer como una pregunta de opción múltiple.
 
 
@@ -255,8 +255,8 @@ def inside(point, lower, higher):
 \end{minted}
 \end{aside}
 
-Los ejercicios de \emph{Tema y variación}son similares, 
-pero se le pide al/a la estudiante que haga una pequeña alteración que cambie la salida de alguna manera específica 
+Los ejercicios de \emph{tema y variación} son similares, 
+pero se le pide al estudiante que haga una pequeña alteración que cambie la salida de alguna manera específica 
 en lugar de realizar un cambio para corregir un error.
 Los cambios permitidos pueden incluir cambiar el valor inicial de una variable, 
 reemplazar una llamada de función por otra, 
@@ -264,7 +264,7 @@ intercambiar bucles internos y externos,
 o cambiar el orden de las pruebas en un condicional complejo
 
 De nuevo,
-este tipo de ejercicio da a los estudiantes y a las estudiantes la oportunidad de practicar una habilidad útil para el mundo real:
+este tipo de ejercicio da a los/las estudiantes la oportunidad de practicar una habilidad útil para el mundo real:
 la forma más rápida de producir el código que necesitan 
 es ajustando un código que ya hace algo parecido.
 
@@ -285,11 +285,11 @@ end
 \end{aside}
 
 Los \emph{ejercicios de modificación} son el complemento de los ejercicios temáticos y de variación: 
-dado un trozo de código que funciona, el/la estudiante tiene que modificarlo de alguna manera sin cambiar la salida.
+dado un fragmento de código que funciona, el/la estudiante tiene que modificarlo de alguna manera sin cambiar la salida.
 
 Por ejemplo, 
 el/la estudiante puede reemplazar los bucles con expresiones vectorizadas
- o simplificar la condición en un bucle while
+ o simplificar la condición en un bucle \emph{while}.
 
 Esta es también una habilidad útil para la vida real, 
 pero a menudo hay tantas formas de modificar el código
@@ -309,18 +309,18 @@ for v in values:
 
 \seclbl{Diagramas}{s:exercises-diagrams}
 
-Hacer que los estudiantes dibujen mapas conceptuales y otros diagramas, brinda una idea de cómo están pensando (\secref{s:memory-concept-maps}),
+Hacer que los estudiantes dibujen mapas conceptuales y otros diagramas brinda una idea de cómo están pensando (\secref{s:memory-concept-maps}),
 pero los diagramas de forma libre requieren tiempo y juicio humano para evaluarlos.
 
 \emph{Etiquetar los diagramas},
 por otra parte, 
 es casi tan potente pedagógicamente  
 pero mucho más fácil de escalar.
-En lugar de hacer que los/las estudiantes creen diagramas desde cero, puedes entregarles un diagrama y un conjunto de etiquetas, y hacer que coloquen las etiquetas en los lugares correctos.
+En lugar de hacer que tus estudiantes creen diagramas desde cero, puedes entregarles un diagrama y un conjunto de etiquetas y hacer que coloquen las etiquetas en los lugares correctos.
 El diagrama puede ser una estructura de datos (``después de ejecutar este código, ¿qué variables apuntan a qué partes de esta estructura?''), un gráfico (``une con flechas cada uno de estos fragmentos de código con la parte del gráfico generado''), o el propio código (``haz coincidir cada término con un ejemplo de ese mismo elemento en el programa'').
 
 \begin{aside}{Etiquetado de un diagrama}
-  \figref{f:exercises-labeling} muestra
+  La \figref{f:exercises-labeling} muestra
 cómo un fragmento pequeño de HTML se representa en memoria.
   Coloca las etiquetas 1--9 sobre los elementos del árbol 
   para mostrar el orden en el que se alcanzan en un recorrido en profundidad.
@@ -335,19 +335,17 @@ Otra forma de usar diagramas es dar a tus estudiantes las partes del diagrama y 
 Este es un equivalente visual a un problema de Parsons, 
 y para ayudar con el etiquetado puedes proporcionar más o menos del esqueleto, de acuerdo a la dificultad para la que crees que están preparados/as.
 
-
-
-Tengo buenas memorias de tratar de colocar resistencias y capacitores en un diagrama de circuito con el fin de obtener el voltaje correcto en un punto determinado, y he visto profesores/as que les dan a sus estudiantes un conjunto definido de bloques de Scratch\index{Scratch} y les piden que creen un diseño particular usando solo esos bloques.
+Tengo buenas memorias de tratar de colocar resistencias y capacitores en un diagrama de circuito con el fin de obtener el voltaje correcto en un punto determinado, y he visto docentes que les dan a sus estudiantes un conjunto definido de bloques de Scratch \index{Scratch} y les piden que creen un diseño particular usando solo esos bloques.
 
 Los \emph{problemas de correspondencia} pueden pensarse como un caso especial de etiquetado 
 en el que el ``diagrama" es una columna de texto 
 y las etiquetas se toman de la otra columna.
 
 En la \emph{correspondencia uno-a-uno} se le da a cada estudiante dos listas de igual longitud y se le pide que asocie los elementos correspondientes, 
-e.g.\ `` asocia cada fragmento de código con la salida que produce".
+p.ej.\ `` asocia cada fragmento de código con la salida que produce".
 
 \begin{aside}{Correspondencia}
-  Asocia cada operador de expresión regular en \figref{f:exercises-matching}
+  Asocia cada operador de expresión regular en la \figref{f:exercises-matching}
   con lo que hace.
 \end{aside}
 
@@ -363,8 +361,8 @@ Los problemas de correspondencia pueden ser implementados en exámenes autocorre
 (como ``A3, B1, C2''), 
 pero eso es burdo y propenso a errores.
 
-Hacer que reconozcan un conjunto de pares correctos en un preguntas de opción múltiple es aún peor, 
-ya que es muy fácil de malinterpretar, lamentablemente .
+Hacer que reconozcan un conjunto de pares correctos en preguntas de opción múltiple es aún peor, 
+ya que es muy fácil de malinterpretar, lamentablemente.
 
 Dibujar o arrastrar funciona mucho mejor, 
 pero puede requerir más trabajo para implementarlo.
@@ -376,9 +374,9 @@ ya que nuestras mentes son bastante buenas en la detección de errores o anomal�
 Los criterios de ranking determinan el nivel de razonamiento requerido.
 
 Si haces que tus estudiantes ordenen los algoritmos del más rápido al más lento, probablemente estés ejercitando la recuperación
-(es decir\  pidiéndoles que reconozcan los nombres de los algoritmos y que sepan sus propiedades), mientras que al pedirles que ordenen las soluciones de las más robustas a las más frágiles, ejercitas su razonamiento y juicio.
+(es decir, pidiéndoles que reconozcan los nombres de los algoritmos y que sepan sus propiedades), mientras que al pedirles que ordenen las soluciones de las más robustas a las más frágiles, ejercitas su razonamiento y juicio.
 
-\emph{Resumir} también requiere que los/as estudiantes/as utilicen un pensamiento de orden superior y les da la oportunidad de practicar una habilidad que es muy útil para informar sobre errores.
+\emph{Resumir} también requiere que los/las estudiantes utilicen un pensamiento de orden superior y les da la oportunidad de practicar una habilidad que es muy útil para informar sobre errores.
 Por ejemplo, 
 les puedes preguntar a tus estudiantes:
  ``¿Qué frase describe mejor cómo cambia la salida de f a medida que  x varía de 0 a 10?" 
@@ -392,7 +390,7 @@ pero las preguntas de este tipo se prestan bien a la clasificación por pares
 (\secref{s:individual-peer}).
 
 \seclbl{Calificación automática}{s:exercises-grading}
-\index{automatic grading}
+\index{calificación automática}
 
 Las herramientas automáticas de corrección de evaluaciones han existido desde antes que yo naciera: la primera mención publicada data de 1960 y las encuestas publicadas por~\cite{Douc2005,Ihan2010} mencionan muchas herramientas específicas por su nombre.
 
@@ -402,55 +400,55 @@ Construir este tipo de herramientas es mucho más complejo de lo que podría par
 
 ¿Cómo se realiza un seguimiento y se informan los envíos?
 
-¿Pueden los/as estudiantes/as trabajar cooperativamente?
+¿Pueden los/las estudiantes trabajar cooperativamente?
 
 ¿Cómo se pueden ejecutar los envíos de forma segura?
 
-\cite{Edwa2014a} es un artículo entero dedicado a un esquema adaptativo para detectar y gestionar bucles infinitos de los envíos de código, y esa es solo uno de las muchos problemas que surgen.
+\cite{Edwa2014a} es un artículo entero dedicado a un esquema adaptativo para detectar y gestionar bucles infinitos de los envíos de código, y este es solo uno de las muchos problemas que surgen.
 
 Cuando se habla de autocalificadores, 
 es importante diferenciar la satisfacción de los/las estudiantes de los resultados del aprendizaje.
 Por ejemplo, 
-\cite{Magu2018} sustituyó los laboratorios informales de programación para un curso de Ciencias de la Computación (\emph{CS} por sus siglas en inglés) de segundo año por una prueba semanal evaluada utilizando un calificador automático.
-A los/as estudiantes/as no les gustó el sistema automatizado, 
+\cite{Magu2018} sustituyó los laboratorios informales de programación para un curso de Ciencias de la Computación de segundo año por una prueba semanal evaluada utilizando un calificador automático.
+A los/las estudiantes no les gustó el sistema automatizado, 
 pero la tasa general de fracasos del curso se redujo a la mitad 
-y se triplicó el número de estudiantes/as que obtuvieron calificaciones con honores.
+y se triplicó el número de estudiantes que obtuvieron calificaciones con honores.
 Por el contrario, 
 \cite{Rubi2014} también comenzó a utilizar un autocalificador diseñado para competencias, pero no vio una disminución significativa en las tasas de deserción de sus estudiantes;
 una vez más, 
 los/las estudiantes hicieron comentarios negativos sobre la herramienta, 
-que los autores atribuyen a la calidad de los mensajes de retroalimentación más que a una aversión a la autocalificación.
+que los/las autores atribuyen a la calidad de los mensajes de retroalimentación más que a una aversión a la autocalificación.
 
 \cite{Srid2016} adoptaron un enfoque diferente.
 Utilizaron \gref{g:fuzz-testing}{fuzz testing} 
 (casos de prueba generados aleatoriamente) 
-para comprobar si el código del/de la estudiante/a realiza lo mismo que una implementación de referencia proporcionada por el profesor.
-En el primer proyecto de un curso introductorio de 1400 estudiantes y estudiantes, el fuzz testing identificó errores que no habían sido detectados en un conjunto de casos de prueba escritos a mano para más del 48% de los estudiantes.
+para comprobar si el código del estudiante realiza lo mismo que una implementación de referencia proporcionada por el profesor.
+En el primer proyecto de un curso introductorio de 1400 estudiantes y estudiantes, el fuzz testing identificó errores que no habían sido detectados en un conjunto de casos de prueba escritos a mano para más del 48\% de los estudiantes.
 
 \cite{Basu2015} dio a sus estudiantes una serie de soluciones a casos de prueba, 
 pero tenían que desbloquear cada caso respondiendo preguntas sobre su comportamiento esperado
 antes de que se les permitiera aplicarlo a la solución propuesta por ellos/as.
 
 Por ejemplo, 
-supongamos que los/as estudiantes/as tenían que escribir una función para encontrar el mayor par de números adyacentes en una lista. Antes de que se les permitiera usar las pruebas de la pregunta, tenían que elegir la respuesta correcta a: ``¿Qué produce \texttt{largestPair(4, 3, -1, 5, 3, 3)}?".
+supongamos que los/las estudiantes tenían que escribir una función para encontrar el mayor par de números adyacentes en una lista. Antes de que se les permitiera usar las pruebas de la pregunta, tenían que elegir la respuesta correcta a: ``¿Qué produce \texttt{largestPair(4, 3, -1, 5, 3, 3)}?".
 En un curso universitario de 1300 personas, 
 la gran mayoría de los/las estudiantes optaron por validar su comprensión de los casos de prueba de esta manera 
 antes de intentar resolver los problemas, 
-y luego hicieron menos preguntas y expresaron menos confusión acerca de las tareas.
+y así hicieron menos preguntas y expresaron menos confusión acerca de las tareas.
 
 \begin{aside}{Contra herramientas disponibles en el mercado}
 Es tentador usar herramientas de revisión de estilo fácilmente disponibles para calificar el código de los/las estudiantes.
 Sin embargo,
-\cite{Nutb2016} inicialmente no encontró correlación entre las calificaciones proporcionadas por personas 
+\cite{Nutb2016} inicialmente no encontraron correlación entre las calificaciones proporcionadas por personas 
 y las violaciones a las reglas del corrector de estilo.
 A veces esto se debía a que los/las estudiantes violaban una regla muchas veces 
 (perdiendo así más puntos de los que deberían haber perdido), 
 pero otras veces se debía a que enviaban el código de inicio de tarea con pocas alteraciones y de esa manera obtenían más puntos de los que deberían haber obtenido.
 
- Incluso las herramientas construidas específicamente para la enseñanza pueden quedar por debajo de las necesidades de los profesores.
+ Incluso las herramientas construidas específicamente para la enseñanza pueden quedar por debajo de las necesidades de los/las docentes.
    \cite{Keun2016a,Keun2016b}  observaron los mensajes producidos por 69 herramientas de calificación automática.
   Encontraron que estas herramientas a menudo no dan retroalimentación sobre cómo solucionar problemas y dar el siguiente paso.
-    También encontraron que la mayoría de los docentes y las docentes no pueden adaptar fácilmente la mayoría de las herramientas a sus necesidades: 
+    También encontraron que la mayoría de los/las docentes no pueden adaptar fácilmente la mayoría de las herramientas a sus necesidades: 
 como muchas herramientas de flujo de trabajo, tienden a hacer cumplir supuestos no reconocidos por sus creadores sobre cómo funcionan las instituciones.
   Su esquema de clasificación es una lista de compras útil cuando se examinan herramientas de este tipo.
 \end{aside}
@@ -459,53 +457,51 @@ como muchas herramientas de flujo de trabajo, tienden a hacer cumplir supuestos 
 Su punto de partida es que, 
 ``Los sistemas de calificación automatizados ayudan a los/las estudiantes a identificar errores en su código, 
 [pero] pueden inadvertidamente disuadir a los/las estudiantes de pensar críticamente y probar a fondo y, en cambio,  
-fomentan dependencia con las pruebas del profesor".
-Una de las cuestiones clave que identificaron es que un/una estudiante puede probar a fondo su código, pero es posible que la característica aún no se implemente de acuerdo con las especificaciones del/de la docente.
+fomentan dependencia con las pruebas del docente".
+Una de las cuestiones clave que identificaron es que un/una estudiante puede probar a fondo su código, pero es posible que la característica aún no se implemente de acuerdo con las especificaciones del docente.
 En este caso, 
-el ``fallo" no es causado por la falta de pruebas, si no por un malentendido de los requisitos, y es poco probable que más pruebas expongan el problema.
+el ``fallo" no es causado por la falta de pruebas sino por un malentendido de los requisitos, y es poco probable que más pruebas expongan el problema.
 
-If the auto-grading system doesn’t provide insightful, actionable feedback, this experience will only frustrate the learner.
-
-Si el sistema de calificación automática no proporciona una retroalimentación que brinde una mejor comprensión y aplicación de los conocimientos, esta experiencia sólo frustrará al estudiante/a.
+Si el sistema de calificación automática no proporciona una retroalimentación que brinde una mejor comprensión y aplicación de los conocimientos, esta experiencia sólo frustrará al estudiante.
 Con el fin de proporcionar esa retroalimentación, 
-el sistema de \cite{Buff2015} identifica qué métodos en el código del/de la estudiante  se ejecutan mediante pruebas fallidas 
+el sistema de \cite{Buff2015} identifica qué métodos en el código del estudiante  se ejecutan mediante pruebas fallidas 
 para que el sistema pueda asociar pruebas fallidas con características particulares de lo que envió el/la estudiante.
-El sistema decide si se han ``ganado" ayudas específicas viendo si el estudiante ha probado la característica asociada lo suficiente, para evitar que los/las estudiantes se apoyen en las ayudas en vez de realizar las pruebas.
+El sistema decide si se han ``ganado" ayudas específicas viendo si el/la estudiante ha probado la característica asociada lo suficiente, para evitar que los/las estudiantes se apoyen en las ayudas en vez de realizar las pruebas.
 En \cite{Srid2016} se describen otros enfoques para compartir la retroalimentación con los/las estudiantes 
 cuando se prueba automáticamente su código.
 Lo primero es proporcionar la salida esperada para las pruebas---pero 
-luego los estudiantes generan la salida de código duro para esas entradas 
-(porque todo lo que se pueda jugar será).
+luego los/las estudiantes generan la salida de código duro para esas entradas 
+(porque todo lo que pueda manipularse se hará).
 
-Lo segundo es informar  los resultados de la aprobación o rechazo del código de los estudiantes, 
+Lo segundo es informar  los resultados de la aprobación o rechazo del código de los/las estudiantes, 
 pero suministrando las entradas y salidas reales de las pruebas solo después de la fecha de envío.
 Sin embargo, 
-decirles a los/las estudiantes que están equivocados/as pero no decirles por qué es frustrante.
+es frustante decirles a los/las estudiantes que están se han equivocado pero no decirles por qué.
 Una tercera opción es utilizar una técnica llamada \gref{g:hashing}{hashing} para generar un valor que depende de la salida pero sin revelarla.
 
-Si el usuario produce exactamente el resultado correcto
+Si el/la usuario/a produce exactamente el resultado correcto
 entonces su hash desbloqueará la solución, 
 pero es imposible hacer el camino inverso a partir del hash para averiguar cuál se supone que es la salida.
 
-Hashing requiere más trabajo y explicación para configurarlo, 
+El hashing requiere más trabajo y explicación para configurarlo, 
 pero logra un buen balance entre revelar respuestas prematuramente  y no revelarlas cuando podría ser de ayuda.
 
 \seclbl{Razonamientos de alto nivel}{s:exercises-higher}
 
-Muchos tipos de ejercicios de programación son difíciles de evaluar por docentes en una clase con más de un puñado de estudiantes, e igualmente difícil para evaluar mediante plataformas automatizadas.
+Muchos tipos de ejercicios de programación son difíciles de evaluar por docentes en una clase con más de un puñado de estudiantes e igualmente difícil para evaluar mediante plataformas automatizadas.
 Las clases van desarrollándose con vistas a proyectos de programación mayores (si todo va bien), 
 pero la única manera de dar retroalimentación es caso por caso.
 La \emph{revisión de código} también es, en general, difícil de calificar automáticamente,
 pero puede ser abordada si se proporciona a  los/las estudiantes una lista de fallos a buscar y se les pide que comparen comentarios con líneas de código concretas.
 
 Por ejemplo, 
-se le puede decir a un estudiante que hay dos errores de sangría y un nombre de variable incorrecto y se le puede pedir que los señale.
+se le puede decir a un/a estudiante que hay dos errores de sangría y un nombre de variable incorrecto y se le puede pedir que los señale.
 
 Si son estudiantes/as más avanzados/as, se les podría dar media docena de tipos de comentarios que podrían hacerse sobre el código sin que se les diga cuánto de cada uno debería encontrar.
 
 \cite{Steg2016b} es un buen punto de partida para una rúbrica de estilo de código, mientras que~\cite{Luxt2009} muestra la revisión por pares en las clases de programación de manera más general.
 
-Si se pide a los/las estudiantes que hagan revisiones, hay que usar la revisión por pares calibrada (\secref{s:individual-peer})\index{calibrated peer review} para que tengan modelos de cómo debería ser una buena retroalimentación.
+Si se pide a los/las estudiantes que hagan revisiones, hay que usar la revisión por pares calibrada (\secref{s:individual-peer})\index{revisión por pares calibrada} para que tengan modelos de cómo debería ser una buena retroalimentación.
 
 \begin{aside}{Revisión de código}
  Marca los problemas en cada línea de código usando la rúbrica proporcionada.
@@ -530,63 +526,62 @@ Si se pide a los/las estudiantes que hagan revisiones, hay que usar la revisión
 
 \seclbl{Ejercicios}{s:exercises-exercises}
 
-\exercise{Programar y ejecutar}{en pares}{10’}
+\exercise{Programar y ejecutar}{parejas}{10’}
 
-Crea un ejercicio corto de \emph{C\&R}, 
-luego intercambia con un par 
-y analiza cuánto tiempo les toma a cada uno de ustedes entender y hacer el ejercicio del otro
+Crea un ejercicio corto de \emph{programa y ejecuta}, 
+luego intercambia con tu pareja 
+y analiza cuánto tiempo les toma a cada uno de ustedes entender y hacer el ejercicio del otro/a.
 
 ¿Hubo alguna ambigüedad o malentendido en la descripción del ejercicio?
 
 \exercise{Invertir el código y la ejecución}{grupos pequeños}{15’}
 
 Forma grupos de 4 a 6 personas.
-Haz que cada miembro del grupo cree un ejercicio de \emph{C\&R} invertido que requiera que las personas averigüen qué entrada produce una salida en particular.
-Elige dos al azar 
+Haz que cada integrante del grupo cree un ejercicio de \emph{programa y ejecuta} invertido que requiera que las personas averigüen qué entrada produce una salida en particular.
+Elige dos ejercicios al azar 
 y mira cuántas entradas diferentes que satisfagan los requisitos puede encontrar el grupo .
 
-\exercise{Siguiendo valores}{en pares}{10’}
+\exercise{Siguiendo valores}{parejas}{10’}
 
 Escribe un programa corto (10-15 líneas),
- intercambia con un par y 
+ intercambia con tu pareja y 
 traza cómo las variables del programa cambian de valor con el tiempo.
-¿Qué diferencias hay en la forma en que tú y tu compañero/a escribieron sus trazas?
+¿Qué diferencias hay en la forma en que tú y tu pareja escribieron sus trazas?
 
-\exercise{Refactoring}{grupos pequeños}{15’}
+\exercise{Refactorizar}{grupos pequeños}{15’}
 
 Forma grupos de 3-4 personas.
 
-
-Haz que cada persona seleccione un fragmento corto de código (10--30 líneas de largo) que haya escrito  que no sea tan ordenado como podría ser, 
-luego elige una estudiante al azar y que todas las personas de la clase lo ordenen independientemente.
+Haz que cada persona seleccione un fragmento corto de código (10--30 líneas de largo) que haya escrito y que no sea tan ordenado como podría ser.
+Luego, elige un/a estudiante al azar y que todas las personas de la clase ordenen su código independientemente.
 
 ¿En qué se diferencian las versiones limpias?
 ¿Qué tan bien o que tan mal podrían acomodarse todas estas variaciones si se calificara automáticamente, o en una clase grande?
 
-\exercise{Rotulando un diagrama}{de a pares}{10’}
+\exercise{Rotulando un diagrama}{parejas}{10’}
 
 Dibuja un diagrama mostrando algo que se ha explicado recientemente: cómo los navegadores obtienen datos de los servidores, la relación entre los objetos y las clases,
 o cómo se indexan los dataframes en R.
 
-Pon las etiquetas en el lateral y pídele a tu compañera que las coloque.
+Pon las etiquetas en el lateral y pídele a tu pareja que las asigne a cada elemento del diagrama.
 
 \exercise{Acertijos de lápiz y papel}{toda la clase}{15’}
 
-\cite{Butl2017} describe un conjunto de rompecabezas de lápiz y papel que pueden convertirse en asignaciones de programación introductorias, señalando que estas tareas son disfrutadas por los/as estudiantes/as y que fomentan la metacognición.
+\cite{Butl2017} describe un conjunto de rompecabezas de lápiz y papel que pueden convertirse en asignaciones de programación introductorias, señalando que estas tareas son disfrutadas por los/las estudiantes y que fomentan la metacognición.
 Piensa en un simple rompecabezas de lápiz y papel al que jugabas en tu niñez
 y describe cómo lo convertirías en un ejercicio de programación.
 
-\exercise{Contando fallos}{de a pares}{15’}
+\exercise{Contando fallos}{parejas}{15’}
 Cualquier estimación útil de cuánto tiempo se necesita para resolver un ejercicio 
 debe considerar cuán frecuentes son los fallos y cuánto tiempo se pierde con ellos.
 Por ejemplo, 
 editar archivos de texto parece una tarea sencilla, 
 pero ¿qué pasa con la búsqueda de esos archivos?
-La mayoría de los editores que usan interfase gráfica (GUI, por su sigla en inglés) guardan archivos en el escritorio o en el directorio personal del usuario/a; si los archivos utilizados en un curso se almacenan en otro lugar, una proporción importante de los/las estudiantes no podrá navegar al directorio correcto sin ayuda.
-(Si esto te parece un problema menor, por favor vuelve a visitar la discusión del punto ciego de las personas expertas en \chapref{s:memory}.)
+La mayoría de los editores que usan interfase gráfica guardan archivos en el escritorio o en el directorio personal del usuario/a; si los archivos utilizados en un curso se almacenan en otro lugar, una proporción importante de los/las estudiantes no podrá navegar al directorio correcto sin ayuda.
+(Si esto te parece un problema menor, por favor vuelve a visitar la discusión del punto ciego de las personas expertas en el \chapref{s:memory}.)
 
 
-Trabajando con un compañero, haz una lista de las cosas ``simples'' que has notado que salen mal en los ejercicios que has usado o tomado.
+Trabajando con tu pareja, haz una lista de las cosas ``simples'' que has notado que salen mal en los ejercicios que has usado o tomado.
 
 ¿Con qué frecuencia aparecen?
 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -473,7 +473,7 @@ Lo primero es proporcionar la salida esperada para las pruebas---pero
 luego los/las estudiantes generan la salida de código duro para esas entradas 
 (porque todo lo que pueda manipularse se hará).
 
-Lo segundo es informar  los resultados de la aprobación o rechazo del código de los/las estudiantes, 
+Lo segundo es informar los resultados de la aprobación o rechazo del código de los/las estudiantes, 
 pero suministrando las entradas y salidas reales de las pruebas solo después de la fecha de envío.
 Sin embargo, 
 es frustante decirles a los/las estudiantes que están se han equivocado pero no decirles por qué.

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -365,7 +365,7 @@ Hacer que reconozcan un conjunto de pares correctos en preguntas de opción múl
 ya que es muy fácil de malinterpretar, lamentablemente.
 
 Dibujar o arrastrar funciona mucho mejor, 
-pero puede requerir más trabajo para implementarlo.
+pero requiere más trabajo para implementarlo.
 
 
 \emph{Ranking} es un caso especial de emparejamiento 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -476,7 +476,7 @@ luego los/las estudiantes generan la salida de código duro para esas entradas
 Lo segundo es informar los resultados de la aprobación o rechazo del código de los/las estudiantes, 
 pero suministrando las entradas y salidas reales de las pruebas solo después de la fecha de envío.
 Sin embargo, 
-es frustante decirles a los/las estudiantes que están se han equivocado pero no decirles por qué.
+es frustante decirles a los/las estudiantes que se han equivocado pero no decirles por qué.
 Una tercera opción es utilizar una técnica llamada \gref{g:hashing}{hashing} para generar un valor que depende de la salida pero sin revelarla.
 
 Si el/la usuario/a produce exactamente el resultado correcto

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -495,7 +495,7 @@ La \emph{revisión de código} también es, en general, difícil de calificar au
 pero puede ser abordada si se proporciona a los/las estudiantes una lista de fallos a buscar y se les pide que comparen comentarios con líneas de código concretas.
 
 Por ejemplo, 
-se le puede decir a un/a estudiante que hay dos errores de sangría y un nombre de variable incorrecto y se le puede pedir que los señale.
+se le puede decir a un/a estudiante que hay dos errores de indentación y un nombre de variable incorrecto y se le puede pedir que los señale.
 
 Si son estudiantes/as más avanzados/as, se les podría dar media docena de tipos de comentarios que podrían hacerse sobre el código sin que se les diga cuántos de cada tipo deberían encontrar.
 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -464,7 +464,7 @@ el ``fallo" no es causado por la falta de pruebas sino por un malentendido de lo
 
 Si el sistema de calificación automática no proporciona una retroalimentación que brinde una mejor comprensión y aplicación de los conocimientos, esta experiencia sólo frustrará al estudiante.
 Con el fin de proporcionar esa retroalimentación, 
-el sistema de \cite{Buff2015} identifica qué métodos en el código del estudiante  se ejecutan mediante pruebas fallidas 
+el sistema de \cite{Buff2015} identifica qué métodos en el código del estudiante se ejecutan mediante pruebas fallidas 
 para que el sistema pueda asociar pruebas fallidas con características particulares de lo que envió el/la estudiante.
 El sistema decide si se han ``ganado" ayudas específicas viendo si el/la estudiante ha probado la característica asociada lo suficiente, para evitar que los/las estudiantes se apoyen en las ayudas en vez de realizar las pruebas.
 En \cite{Srid2016} se describen otros enfoques para compartir la retroalimentación con los/las estudiantes 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -404,7 +404,7 @@ Construir este tipo de herramientas es mucho más complejo de lo que podría par
 
 ¿Cómo se pueden ejecutar los envíos de forma segura?
 
-\cite{Edwa2014a} es un artículo entero dedicado a un esquema adaptativo para detectar y gestionar bucles infinitos de los envíos de código, y este es solo uno de las muchos problemas que surgen.
+\cite{Edwa2014a} es un artículo dedicado por completo a un esquema adaptativo para detectar y gestionar bucles infinitos de los envíos de código, y este es solo uno de las muchos problemas que surgen.
 
 Cuando se habla de autocalificadores, 
 es importante diferenciar la satisfacción de los/las estudiantes de los resultados del aprendizaje.

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -546,7 +546,7 @@ y mira cuántas entradas diferentes que satisfagan los requisitos puede encontra
 Escribe un programa corto (10-15 líneas),
  intercambia con tu pareja y 
 sigue cómo las variables del programa cambian de valor con el tiempo.
-¿Qué diferencias hay en la forma en que tú y tu pareja escribieron sus trazas?
+¿Qué diferencias hay en la forma en que tú y tu pareja escribieron sus seguimientos?
 
 \exercise{Refactorizar}{grupos pequeños}{15’}
 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -477,7 +477,7 @@ Lo segundo es informar los resultados de la aprobación o rechazo del código de
 pero suministrando las entradas y salidas reales de las pruebas solo después de la fecha de envío.
 Sin embargo, 
 es frustante decirles a los/las estudiantes que se han equivocado pero no decirles por qué.
-Una tercera opción es utilizar una técnica llamada \gref{g:hashing}{hashing} para generar un valor que depende de la salida pero sin revelarla.
+Una tercera opción es utilizar una técnica llamada \gref{g:hashing}{\emph{hashing}} para generar un valor que depende de la salida pero sin revelarla.
 
 Si el/la usuario/a produce exactamente el resultado correcto
 entonces su hash desbloqueará la solución, 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -169,7 +169,7 @@ D)         pass
 \end{minted}
 \end{aside}
 
-\emph{Seguir los valores} es similar a trazar la ejecución, 
+\emph{Seguir los valores} es similar a seguir la ejecución, 
 pero en lugar de deletrear el orden en que se ejecuta el código, 
 el/la estudiante enumera los valores que una o más variables toman
  a medida que se ejecuta el programa.

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -77,7 +77,7 @@ se les puede pedir a los/las estudiantes que escriban pruebas para determinar si
 Esta habilidad es útil por sí misma y practicarla puede darles a los/las estudiantes un poco más de simpatía por el trabajo duro de sus docentes.
 
 \begin{aside}{Invirtiendo programar y ejecutar}
- La función \texttt{monotonic\_sum} calcula la suma de cada sección de una lista de números, en la que los valores aumentan estrictamente.
+ La función \texttt{suma\_monotona} calcula la suma de cada sección de una lista de números, en la que los valores aumentan estrictamente.
 
 Por ejemplo,
   dada la entrada \texttt{[1,\ 3,\ 3,\ 4,\ 5,\ 1]},

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -437,7 +437,7 @@ antes de intentar resolver los problemas,
 y así hicieron menos preguntas y expresaron menos confusión acerca de las tareas.
 
 \begin{aside}{En contra de las herramientas ``listas para usar" disponibles en el mercado}
-Es tentador usar herramientas de revisión de estilo fácilmente disponibles para calificar el código de los/las estudiantes.
+Es tentador calificar el código de los/las estudiantes con herramientas de revisión de estilo disponibles y de acceso sencillo.
 Sin embargo,
 \cite{Nutb2016} inicialmente no encontraron correlación entre las calificaciones proporcionadas por personas 
 y las violaciones a las reglas del corrector de estilo.

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -101,7 +101,7 @@ Escribe y corre pruebas unitarias para determinar cuál de los siguientes errore
 \emph{Completar los espacios en blanco} es un refinamiento de \emph{programar y ejecutar}
 en el que el/la estudiante recibe el comienzo de un código y debe completarlo.
 
-(En la práctica, la mayoría de los ejercicios \emph{programa y ejecuta} son en realidad del tipo de llenar los espacios en blanco, porque el/la docente proporciona comentarios
+(En la práctica, la mayoría de los ejercicios \emph{programar y ejecutar} son en realidad del tipo completar los espacios en blanco, porque el/la docente proporciona comentarios
 para recordarles a sus estudiantes los pasos que deben seguir. 
 Las preguntas de este tipo son las bases para ejemplos desvanecidos;
 como se discute en el \chapref{s:architecture},

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -373,7 +373,7 @@ que es (ligeramente) más fácil de responder a través de listas,
 ya que nuestras mentes son bastante buenas en la detección de errores o anomalías en las secuencias.
 Los criterios de ranking determinan el nivel de razonamiento requerido.
 
-Si haces que tus estudiantes ordenen los algoritmos del más rápido al más lento, probablemente estés ejercitando la recuperación
+Si haces que tus estudiantes ordenen los algoritmos del más rápido al más lento, probablemente estés ejercitando la memoria
 (es decir, pidiéndoles que reconozcan los nombres de los algoritmos y que sepan sus propiedades), mientras que al pedirles que ordenen las soluciones de las más robustas a las más frágiles, ejercitas su razonamiento y juicio.
 
 \emph{Resumir} también requiere que los/las estudiantes utilicen un pensamiento de orden superior y les da la oportunidad de practicar una habilidad que es muy útil para informar sobre errores.

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -423,7 +423,7 @@ que los/las autores atribuyen a la calidad de los mensajes de retroalimentación
 Utilizaron \gref{g:fuzz-testing}{fuzz testing} 
 (casos de prueba generados aleatoriamente) 
 para comprobar si el código del estudiante realiza lo mismo que una implementación de referencia proporcionada por el/la docente.
-En el primer proyecto de un curso introductorio de 1400 estudiantes y estudiantes, el fuzz testing identificó errores que no habían sido detectados en un conjunto de casos de prueba escritos a mano para más del 48\% de los estudiantes.
+En el primer proyecto de un curso introductorio de 1400 estudiantes, el \emph{fuzz testing} identificó errores que no habían sido detectados en un conjunto de casos de prueba escritos a mano para más del 48\% de los/las estudiantes.
 
 \cite{Basu2015} dio a sus estudiantes una serie de soluciones a casos de prueba, 
 pero tenían que desbloquear cada caso respondiendo preguntas sobre su comportamiento esperado

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -483,7 +483,7 @@ Si el/la usuario/a produce exactamente el resultado correcto
 entonces su \emph{hash} desbloqueará la solución, 
 pero es imposible hacer el camino inverso a partir del \emph{hash} para averiguar cuál se supone que es la salida.
 
-El hashing requiere más trabajo y explicación para configurarlo, 
+El \emph{hashing} requiere más trabajo y explicación para configurarlo, 
 pero logra un buen balance entre revelar respuestas prematuramente  y no revelarlas cuando podría ser de ayuda.
 
 \seclbl{Razonamientos de alto nivel}{s:exercises-higher}

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -430,7 +430,7 @@ pero tenían que desbloquear cada caso respondiendo preguntas sobre su comportam
 antes de que se les permitiera aplicarlo a la solución propuesta por ellos/as.
 
 Por ejemplo, 
-supongamos que los/las estudiantes tenían que escribir una función para encontrar el mayor par de números adyacentes en una lista. Antes de que se les permitiera usar las pruebas de la pregunta, tenían que elegir la respuesta correcta a: ``¿Qué produce \texttt{largestPair(4, 3, -1, 5, 3, 3)}?".
+supongamos que los/las estudiantes tenían que escribir una función para encontrar el mayor par de números adyacentes en una lista. Antes de que se les permitiera usar las pruebas de la pregunta, tenían que elegir la respuesta correcta a: ``¿Qué produce \texttt{parMasGrande(4, 3, -1, 5, 3, 3)}?".
 En un curso universitario de 1300 personas, 
 la gran mayoría de los/las estudiantes optaron por validar su comprensión de los casos de prueba de esta manera 
 antes de intentar resolver los problemas, 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -98,7 +98,7 @@ Escribe y corre pruebas unitarias para determinar cuál de los siguientes errore
 \end{aside}
 
 
-\emph{Llenar los espacios en blanco} es un refinamiento de \emph{programa y ejecuta}
+\emph{Completar los espacios en blanco} es un refinamiento de \emph{programar y ejecutar}
 en el que el/la estudiante recibe el comienzo de un código y debe completarlo.
 
 (En la práctica, la mayoría de los ejercicios \emph{programa y ejecuta} son en realidad del tipo de llenar los espacios en blanco, porque el/la docente proporciona comentarios

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -446,7 +446,7 @@ A veces esto se debía a que los/las estudiantes violaban una regla muchas veces
 pero otras veces se debía a que enviaban el código de inicio de tarea con pocas alteraciones y de esa manera obtenían más puntos de los que deberían haber obtenido.
 
  Incluso las herramientas construidas específicamente para enseñar pueden quedar por debajo de las necesidades de los/las docentes.
-   \cite{Keun2016a,Keun2016b}  observaron los mensajes producidos por 69 herramientas de calificación automática.
+   \cite{Keun2016a,Keun2016b} observaron los mensajes producidos por 69 herramientas de calificación automática.
   Encontraron que estas herramientas a menudo no dan retroalimentación sobre cómo solucionar problemas y dar el siguiente paso.
     También encontraron que la mayoría de los/las docentes no pueden adaptar fácilmente la mayoría de las herramientas a sus necesidades: 
 como muchas herramientas de flujo de trabajo, tienden a hacer cumplir supuestos no reconocidos por sus creadores sobre cómo funcionan las instituciones.

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -194,7 +194,7 @@ D)     izquierda, derecha = derecha, izquierda % derecha
 \begin{center}
 \begin{tabular}{|l|l|l|}
   \hline
-  Line & \texttt{izquierda} & \texttt{derecha} \\
+  Número de línea & \texttt{izquierda} & \texttt{derecha} \\
   \hline
   & & \\
   \hline

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -470,7 +470,7 @@ El sistema decide si se han ``ganado" ayudas específicas viendo si el/la estudi
 En \cite{Srid2016} se describen otros enfoques para compartir la retroalimentación con los/las estudiantes 
 cuando se prueba automáticamente su código.
 Lo primero es proporcionar la salida esperada para las pruebas---pero 
-luego los/las estudiantes generan la salida de código duro para esas entradas 
+luego los/las estudiantes generan la salida conocida incrustando el dato directamente en el código fuente del programa \footnote{esta práctica se conoce como \emph{hardcodear}} y dejandola fija para esas entradas
 (porque todo lo que pueda manipularse se hará).
 
 Lo segundo es informar los resultados de la aprobación o rechazo del código de los/las estudiantes, 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -10,7 +10,7 @@ Nuestra discusión se basa parcialmente en el Banco de Preguntas de Canterbury \
 
 \seclbl{Los clásicos}{s:exercises-classics}
 
-Como se discute en \secref{s:models-formative-assessment}, las \emph{preguntas de opción múltiple} son más efectivas cuando las respuestas incorrectas sondean conceptos erróneos específicos.  
+Como se discute en la \secref{s:models-formative-assessment}, las \emph{preguntas de opción múltiple} son más efectivas cuando las respuestas incorrectas sondean conceptos erróneos específicos.  
 Están diseñadas para evaluar los niveles más bajos en la Taxonomía de Bloom \index{Taxonomía de Bloom}
 (\secref{s:process-objectives}), pero también requieren que los/las estudiantes utilicen su propio juicio.
 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -114,7 +114,7 @@ las respuestas enviadas son mucho más predecibles y, por lo tanto, más fácile
  para que el código de abajo imprima el texto  \texttt{'cana'}.
 
 \begin{minted}{text}
-text = 'todo lo que es'
+text = 'Un canario que ladra si está triste'
 slice = text[____:____]
 print(slice)
 \end{minted}

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -259,7 +259,7 @@ Los ejercicios de \emph{tema y variación} son similares,
 pero se le pide al estudiante que haga una pequeña alteración que cambie la salida de alguna manera específica 
 en lugar de realizar un cambio para corregir un error.
 Los cambios permitidos pueden incluir cambiar el valor inicial de una variable, 
-reemplazar una llamada de función por otra, 
+reemplazar una llamada a una función por otra, 
 intercambiar bucles internos y externos,
 o cambiar el orden de las pruebas en un condicional complejo
 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -445,7 +445,7 @@ A veces esto se debía a que los/las estudiantes violaban una regla muchas veces
 (perdiendo así más puntos de los que deberían haber perdido), 
 pero otras veces se debía a que enviaban el código de inicio de tarea con pocas alteraciones y de esa manera obtenían más puntos de los que deberían haber obtenido.
 
- Incluso las herramientas construidas específicamente para la enseñanza pueden quedar por debajo de las necesidades de los/las docentes.
+ Incluso las herramientas construidas específicamente para enseñar pueden quedar por debajo de las necesidades de los/las docentes.
    \cite{Keun2016a,Keun2016b}  observaron los mensajes producidos por 69 herramientas de calificación automática.
   Encontraron que estas herramientas a menudo no dan retroalimentación sobre cómo solucionar problemas y dar el siguiente paso.
     También encontraron que la mayoría de los/las docentes no pueden adaptar fácilmente la mayoría de las herramientas a sus necesidades: 

--- a/es/exercises.tex
+++ b/es/exercises.tex
@@ -224,7 +224,7 @@ contribuyen a que los/las estudiantes desarrollen habilidades valiosas de depura
 
 \begin{minted}{text}
 valores = [ [1.0, -0.5], [3.0, 1.5], [2.5, ___] ]
-runningTotal = 0.0
+corridaTotal = 0.0
 for (reading, scaling) in valores:
     runningTotal += reading / scaling
 \end{minted}


### PR DESCRIPTION
- Revisión de lenguaje no sexista

- Hay varios ejercicios de programación. Me parece que hay que traducir el nombre de los objetos/variables. Lo hice en un algunos, pero después dudé de la sintaxis (no quiero traducir una función). Requiere 2da edición de @yabellini

- Dejé en inglés algunos términos que deberían ir a glosario. Ej: hashing.

- "because anything that can be gamed will be", estaba "porque todo lo que se pueda jugar será", lo dejé "porque todo lo que pueda manipularse se hará".

- revisión de número de personas en ejercicios
