### PR TITLE
Fix minor Python example syntax/logic errors

### DIFF
--- a/en/architecture.tex
+++ b/en/architecture.tex
@@ -253,10 +253,10 @@ how to find the total length of a list of words:
 
 \begin{minted}{text}
 # total_length(["red", "green", "blue"]) => 12
-define total_length(list_of_words):
+def total_length(list_of_words):
     total = 0
     for word in list_of_words:
-        total = total + length(word)
+        total = total + len(word)
     return total
 \end{minted}
 
@@ -266,10 +266,10 @@ and then ask them to fill in the blanks in this
 
 \begin{minted}{text}
 # word_lengths(["red", "green", "blue"]) => [3, 5, 4]
-define word_lengths(list_of_words):
+def word_lengths(list_of_words):
     list_of_lengths = []
     for ____ in ____:
-        append(list_of_lengths, ____)
+        list_of_lengths.append(____)
     return list_of_lengths
 \end{minted}
 
@@ -278,7 +278,7 @@ The next problem might be this
 
 \begin{minted}{text}
 # join_all(["red", "green", "blue"]) => "redgreenblue"
-define join_all(list_of_words):
+def join_all(list_of_words):
     joined_words = ____
     for ____ in ____:
         ____
@@ -289,7 +289,7 @@ Learners would finally be asked to write an entire function on their own:
 
 \begin{minted}{text}
 # make_acronym(["red", "green", "blue"]) => "RGB"
-define make_acronym(list_of_words):
+def make_acronym(list_of_words):
     ____
 \end{minted}
 

--- a/es/architecture.tex
+++ b/es/architecture.tex
@@ -248,10 +248,10 @@ cómo encontrar la longitud total de una lista de palabras:
 
 \begin{minted}{text}
 # largo_total(["rojo", "verde", "azul"]) => 12
-define largo_total(lista_de_palabras):
+def largo_total(lista_de_palabras):
     total = 0
     for palabra in lista_de_palabras:
-        total = total + length(palabra)
+        total = total + len(palabra)
     return total
 \end{minted}
 
@@ -263,10 +263,10 @@ y luego pidiendo que llenen los espacios en blanco en este otro código
 
 \begin{minted}{text}
 # largo_palabra(["rojo", "verde", "azul"]) => [3, 5, 4]
-define largo_palabra(lista_de_palabras):
+def largo_palabra(lista_de_palabras):
     lista_de_longitudes = []
     for ____ in ____:
-        append(lista_de_longitudes, ____)
+        lista_de_longitudes.append(____)
     return lista_de_longitudes
 \end{minted}
 
@@ -275,7 +275,7 @@ El siguiente problema podría ser este
 
 \begin{minted}{text}
 # juntar_todo(["rojo", "verde", "azul"]) => "rojoverdeazul"
-define juntar_todo(lista_de_palabras):
+def juntar_todo(lista_de_palabras):
     palabras_unidas = ____
     for ____ in ____:
         ____
@@ -286,7 +286,7 @@ Finalmente, los/las estudiantes tendrán que escribir una función completa por 
 
 \begin{minted}{text}
 # generar_acronimo(["rojo", "verde", "azul"]) => "RVA"
-define generar_acronimo(lista_de_palabras):
+def generar_acronimo(lista_de_palabras):
     ____
 \end{minted}
 


### PR DESCRIPTION
Some python code in the faded examples section aren't quite valid Python.  This PR makes it something a Python interpreter will accept.